### PR TITLE
fix: add parent-child relationship support for createWorkItem

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Run prettier
+npm run format
+
+# Run eslint
+npm run lint 

--- a/src/features/work-items/create-work-item/feature.spec.int.ts
+++ b/src/features/work-items/create-work-item/feature.spec.int.ts
@@ -172,12 +172,13 @@ describe('createWorkItem integration', () => {
     // We would need to fetch the relations, but for now we'll just assert
     // that the response indicates a relationship was created
     expect(childResult.relations).toBeDefined();
-    
+
     // Check that at least one relation exists that points to our parent
     const parentRelation = childResult.relations?.find(
-      relation => 
-        relation.rel === 'System.LinkTypes.Hierarchy-Reverse' && 
-        relation.url && relation.url.includes(`/${parentId}`)
+      (relation) =>
+        relation.rel === 'System.LinkTypes.Hierarchy-Reverse' &&
+        relation.url &&
+        relation.url.includes(`/${parentId}`),
     );
     expect(parentRelation).toBeDefined();
   });

--- a/src/features/work-items/create-work-item/feature.ts
+++ b/src/features/work-items/create-work-item/feature.ts
@@ -75,6 +75,18 @@ export async function createWorkItem(
       });
     }
 
+    // Add parent relationship if parentId is provided
+    if (options.parentId) {
+      document.push({
+        op: 'add',
+        path: '/relations/-',
+        value: {
+          rel: 'System.LinkTypes.Hierarchy-Reverse',
+          url: `${connection.serverUrl}/_apis/wit/workItems/${options.parentId}`,
+        },
+      });
+    }
+
     // Add any additional fields
     if (options.additionalFields) {
       for (const [key, value] of Object.entries(options.additionalFields)) {

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -44,6 +44,10 @@ export const CreateWorkItemSchema = z.object({
     .optional()
     .describe('The iteration path for the work item'),
   priority: z.number().optional().describe('The priority of the work item'),
+  parentId: z
+    .number()
+    .optional()
+    .describe('The ID of the parent work item to create a relationship with'),
   additionalFields: z
     .record(z.string(), z.any())
     .optional()

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -25,6 +25,7 @@ export interface CreateWorkItemOptions {
   areaPath?: string;
   iterationPath?: string;
   priority?: number;
+  parentId?: number;
   additionalFields?: Record<string, string | number | boolean | null>;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -198,6 +198,7 @@ export function createAzureDevOpsServer(config: AzureDevOpsConfig): Server {
               areaPath: args.areaPath,
               iterationPath: args.iterationPath,
               priority: args.priority,
+              parentId: args.parentId,
               additionalFields: args.additionalFields,
             },
           );


### PR DESCRIPTION
This pull request introduces the ability to create a child work item with a parent-child relationship in the Azure DevOps integration. The changes span multiple files and add support for specifying a parent work item when creating a new work item.

The most important changes include:

### Integration Test Enhancement:
* Added a new test case to `src/features/work-items/create-work-item/feature.spec.int.ts` to verify the creation of a child work item with a parent-child relationship. This test ensures that the relationship is correctly established and validated.

### Feature Implementation:
* Modified `createWorkItem` function in `src/features/work-items/create-work-item/feature.ts` to handle the addition of a parent relationship if a `parentId` is provided in the options.

### Schema Update:
* Updated `CreateWorkItemSchema` in `src/features/work-items/schemas.ts` to include an optional `parentId` field for specifying the ID of the parent work item.

### Type Definition:
* Added `parentId` to the `CreateWorkItemOptions` interface in `src/features/work-items/types.ts` to support the new functionality.

### Server Configuration:
* Updated `createAzureDevOpsServer` function in `src/server.ts` to pass the `parentId` argument when creating a work item.

#34