### PR TITLE
feat: Make projectId optional in search features for organization-wide search

### DIFF
--- a/docs/tools/search.md
+++ b/docs/tools/search.md
@@ -11,7 +11,7 @@ The `search_code` tool allows you to search for code across repositories in an A
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | searchText | string | Yes | The text to search for in the code |
-| projectId | string | Yes | The ID or name of the project to search in |
+| projectId | string | No | The ID or name of the project to search in. If not provided, search will be performed across all projects in the organization. |
 | filters | object | No | Optional filters to narrow search results |
 | filters.Repository | string[] | No | Filter by repository names |
 | filters.Path | string[] | No | Filter by file paths |
@@ -46,6 +46,14 @@ The response includes:
 {
   "searchText": "function searchCode",
   "projectId": "MyProject"
+}
+```
+
+#### Organization-wide Search
+
+```json
+{
+  "searchText": "function searchCode"
 }
 ```
 
@@ -92,3 +100,4 @@ The response includes:
 - When `includeContent` is true, the tool makes additional API calls to fetch the full content of each file in the search results.
 - The search API supports a variety of search syntax, including wildcards, exact phrases, and boolean operators. See the [Azure DevOps Search documentation](https://learn.microsoft.com/en-us/azure/devops/project/search/get-started-search?view=azure-devops) for more information.
 - The `CodeElement` filter allows you to filter by code element types such as `function`, `class`, `method`, `property`, `variable`, `comment`, etc.
+- When `projectId` is not provided, the search will be performed across all projects in the organization, which can be useful for finding examples of specific code patterns or libraries used across the organization.

--- a/src/features/search/schemas.ts
+++ b/src/features/search/schemas.ts
@@ -5,7 +5,12 @@ import { z } from 'zod';
  */
 export const SearchCodeSchema = z.object({
   searchText: z.string().describe('The text to search for'),
-  projectId: z.string().describe('The ID or name of the project to search in'),
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID or name of the project to search in. If not provided, search across all projects.',
+    ),
   filters: z
     .object({
       Repository: z
@@ -51,7 +56,12 @@ export const SearchCodeSchema = z.object({
  */
 export const SearchWikiSchema = z.object({
   searchText: z.string().describe('The text to search for in wikis'),
-  projectId: z.string().describe('The ID or name of the project to search in'),
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID or name of the project to search in. If not provided, search across all projects.',
+    ),
   filters: z
     .object({
       Project: z
@@ -85,7 +95,12 @@ export const SearchWikiSchema = z.object({
  */
 export const SearchWorkItemsSchema = z.object({
   searchText: z.string().describe('The text to search for in work items'),
-  projectId: z.string().describe('The ID or name of the project to search in'),
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID or name of the project to search in. If not provided, search across all projects.',
+    ),
   filters: z
     .object({
       'System.TeamProject': z

--- a/src/features/search/search-wiki/feature.spec.unit.ts
+++ b/src/features/search/search-wiki/feature.spec.unit.ts
@@ -1,11 +1,168 @@
+import { WebApi } from 'azure-devops-node-api';
+import axios from 'axios';
 import { searchWiki } from './feature';
 
-// Mock the dependencies
-jest.mock('azure-devops-node-api');
-jest.mock('axios');
+// Mock Azure Identity
+jest.mock('@azure/identity', () => {
+  const mockGetToken = jest.fn().mockResolvedValue({ token: 'mock-token' });
+  return {
+    DefaultAzureCredential: jest.fn().mockImplementation(() => ({
+      getToken: mockGetToken,
+    })),
+    AzureCliCredential: jest.fn().mockImplementation(() => ({
+      getToken: mockGetToken,
+    })),
+  };
+});
 
-describe('searchWiki', () => {
-  it('should be defined', () => {
-    expect(searchWiki).toBeDefined();
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('searchWiki unit', () => {
+  // Mock WebApi connection
+  const mockConnection = {
+    _getHttpClient: jest.fn().mockReturnValue({
+      getAuthorizationHeader: jest.fn().mockReturnValue('Bearer mock-token'),
+    }),
+    getCoreApi: jest.fn().mockImplementation(() => ({
+      getProjects: jest
+        .fn()
+        .mockResolvedValue([{ name: 'TestProject', id: 'project-id' }]),
+    })),
+    serverUrl: 'https://dev.azure.com/testorg',
+  } as unknown as WebApi;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return wiki search results with project ID', async () => {
+    // Arrange
+    const mockSearchResponse = {
+      data: {
+        count: 1,
+        results: [
+          {
+            fileName: 'Example Page',
+            path: '/Example Page',
+            collection: {
+              name: 'DefaultCollection',
+            },
+            project: {
+              name: 'TestProject',
+              id: 'project-id',
+            },
+            hits: [
+              {
+                content: 'This is an example page',
+                charOffset: 5,
+                length: 7,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockedAxios.post.mockResolvedValueOnce(mockSearchResponse);
+
+    // Act
+    const result = await searchWiki(mockConnection, {
+      searchText: 'example',
+      projectId: 'TestProject',
+    });
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.count).toBe(1);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].fileName).toBe('Example Page');
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'https://almsearch.dev.azure.com/testorg/TestProject/_apis/search/wikisearchresults',
+      ),
+      expect.objectContaining({
+        searchText: 'example',
+        filters: expect.objectContaining({
+          Project: ['TestProject'],
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  test('should perform organization-wide wiki search when projectId is not provided', async () => {
+    // Arrange
+    const mockSearchResponse = {
+      data: {
+        count: 2,
+        results: [
+          {
+            fileName: 'Example Page 1',
+            path: '/Example Page 1',
+            collection: {
+              name: 'DefaultCollection',
+            },
+            project: {
+              name: 'Project1',
+              id: 'project-id-1',
+            },
+            hits: [
+              {
+                content: 'This is an example page',
+                charOffset: 5,
+                length: 7,
+              },
+            ],
+          },
+          {
+            fileName: 'Example Page 2',
+            path: '/Example Page 2',
+            collection: {
+              name: 'DefaultCollection',
+            },
+            project: {
+              name: 'Project2',
+              id: 'project-id-2',
+            },
+            hits: [
+              {
+                content: 'This is another example page',
+                charOffset: 5,
+                length: 7,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockedAxios.post.mockResolvedValueOnce(mockSearchResponse);
+
+    // Act
+    const result = await searchWiki(mockConnection, {
+      searchText: 'example',
+    });
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.count).toBe(2);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0].project.name).toBe('Project1');
+    expect(result.results[1].project.name).toBe('Project2');
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'https://almsearch.dev.azure.com/testorg/_apis/search/wikisearchresults',
+      ),
+      expect.not.objectContaining({
+        filters: expect.objectContaining({
+          Project: expect.anything(),
+        }),
+      }),
+      expect.any(Object),
+    );
   });
 });

--- a/src/features/search/search-work-items/feature.ts
+++ b/src/features/search/search-work-items/feature.ts
@@ -31,7 +31,9 @@ export async function searchWorkItems(
       $skip: options.skip,
       $top: options.top,
       filters: {
-        'System.TeamProject': [options.projectId],
+        ...(options.projectId
+          ? { 'System.TeamProject': [options.projectId] }
+          : {}),
         ...options.filters,
       },
       includeFacets: options.includeFacets,
@@ -48,7 +50,11 @@ export async function searchWorkItems(
     );
 
     // Make the search API request
-    const searchUrl = `https://almsearch.dev.azure.com/${organization}/${project}/_apis/search/workitemsearchresults?api-version=7.1`;
+    // If projectId is provided, include it in the URL, otherwise perform organization-wide search
+    const searchUrl = options.projectId
+      ? `https://almsearch.dev.azure.com/${organization}/${project}/_apis/search/workitemsearchresults?api-version=7.1`
+      : `https://almsearch.dev.azure.com/${organization}/_apis/search/workitemsearchresults?api-version=7.1`;
+
     const searchResponse = await axios.post<WorkItemSearchResponse>(
       searchUrl,
       searchRequest,
@@ -101,12 +107,12 @@ export async function searchWorkItems(
  * Extract organization and project from the connection URL
  *
  * @param connection The Azure DevOps WebApi connection
- * @param projectId The project ID or name
+ * @param projectId The project ID or name (optional)
  * @returns The organization and project
  */
 function extractOrgAndProject(
   connection: WebApi,
-  projectId: string,
+  projectId?: string,
 ): { organization: string; project: string } {
   // Extract organization from the connection URL
   const url = connection.serverUrl;
@@ -121,7 +127,7 @@ function extractOrgAndProject(
 
   return {
     organization,
-    project: projectId,
+    project: projectId || '',
   };
 }
 

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -3,7 +3,7 @@
  */
 export interface SearchCodeOptions {
   searchText: string;
-  projectId: string;
+  projectId?: string;
   filters?: {
     Repository?: string[];
     Path?: string[];
@@ -128,8 +128,9 @@ export interface SearchWikiOptions {
 
   /**
    * The ID or name of the project to search in
+   * If not provided, search will be performed across the entire organization
    */
-  projectId: string;
+  projectId?: string;
 
   /**
    * Optional filters to narrow search results
@@ -362,8 +363,9 @@ export interface SearchWorkItemsOptions {
 
   /**
    * The ID or name of the project to search in
+   * If not provided, search will be performed across the entire organization
    */
-  projectId: string;
+  projectId?: string;
 
   /**
    * Optional filters to narrow search results


### PR DESCRIPTION
This PR addresses issue #126 by making the projectId parameter optional in global search features. When projectId is not provided, the search will be performed across the entire Azure DevOps organization instead of a specific project. This enables the MCP client to respond to queries about code examples across all projects in the organization.