### PR TITLE
fix: getMe profile bug

### DIFF
--- a/src/features/users/get-me/feature.spec.int.ts
+++ b/src/features/users/get-me/feature.spec.int.ts
@@ -29,9 +29,11 @@ describe('getMe Integration', () => {
     expect(typeof result.id).toBe('string');
     expect(result.displayName).toBeDefined();
     expect(typeof result.displayName).toBe('string');
+    expect(result.displayName.length).toBeGreaterThan(0);
 
-    // Email might be empty in some environments, but it should be a string
-    expect(result.email !== undefined).toBe(true);
+    // Email should be defined, a string, and not empty
+    expect(result.email).toBeDefined();
     expect(typeof result.email).toBe('string');
+    expect(result.email.length).toBeGreaterThan(0);
   });
 });

--- a/src/features/users/get-me/feature.spec.unit.ts
+++ b/src/features/users/get-me/feature.spec.unit.ts
@@ -42,10 +42,11 @@ describe('getMe', () => {
     // Arrange
     const mockProfile = {
       id: 'user-id-123',
-      coreAttributes: {
-        DisplayName: { value: 'Test User' },
-        Email: { value: 'test.user@example.com' },
-      },
+      displayName: 'Test User',
+      emailAddress: 'test.user@example.com',
+      coreRevision: 1647,
+      timeStamp: '2023-01-01T00:00:00.000Z',
+      revision: 1647,
     };
 
     // Mock axios get to return profile data
@@ -67,14 +68,15 @@ describe('getMe', () => {
     });
   });
 
-  it('should handle missing email attribute', async () => {
+  it('should handle missing email', async () => {
     // Arrange
     const mockProfile = {
       id: 'user-id-123',
-      coreAttributes: {
-        DisplayName: { value: 'Test User' },
-        // No Email attribute
-      },
+      displayName: 'Test User',
+      // No emailAddress
+      coreRevision: 1647,
+      timeStamp: '2023-01-01T00:00:00.000Z',
+      revision: 1647,
     };
 
     // Mock axios get to return profile data
@@ -87,14 +89,15 @@ describe('getMe', () => {
     expect(result.email).toBe('');
   });
 
-  it('should handle missing display name attribute', async () => {
+  it('should handle missing display name', async () => {
     // Arrange
     const mockProfile = {
       id: 'user-id-123',
-      coreAttributes: {
-        // No DisplayName attribute
-        Email: { value: 'test.user@example.com' },
-      },
+      // No displayName
+      emailAddress: 'test.user@example.com',
+      coreRevision: 1647,
+      timeStamp: '2023-01-01T00:00:00.000Z',
+      revision: 1647,
     };
 
     // Mock axios get to return profile data
@@ -105,26 +108,6 @@ describe('getMe', () => {
 
     // Assert
     expect(result.displayName).toBe('');
-  });
-
-  it('should handle alternative email attribute name', async () => {
-    // Arrange
-    const mockProfile = {
-      id: 'user-id-123',
-      coreAttributes: {
-        DisplayName: { value: 'Test User' },
-        emailAddress: { value: 'alt.email@example.com' }, // Using alternative name
-      },
-    };
-
-    // Mock axios get to return profile data
-    mockAxios.get.mockResolvedValue({ data: mockProfile });
-
-    // Act
-    const result = await getMe(mockConnection);
-
-    // Assert
-    expect(result.email).toBe('alt.email@example.com');
   });
 
   it('should handle authentication errors', async () => {

--- a/src/features/users/get-me/feature.ts
+++ b/src/features/users/get-me/feature.ts
@@ -39,17 +39,11 @@ export async function getMe(connection: WebApi): Promise<UserProfile> {
 
     const profile = response.data;
 
-    // Extract email from coreAttributes
-    const emailAttribute = profile.coreAttributes
-      ? profile.coreAttributes['Email'] ||
-        profile.coreAttributes['emailAddress']
-      : undefined;
-
     // Return the user profile with required fields
     return {
       id: profile.id,
-      displayName: profile.coreAttributes?.DisplayName?.value || '',
-      email: emailAttribute?.value || '',
+      displayName: profile.displayName || '',
+      email: profile.emailAddress || '',
     };
   } catch (error) {
     // Handle authentication errors


### PR DESCRIPTION
Fixed a bug with the getMe feature where displayName and email were empty strings. Updated implementation to use direct profile properties according to the Azure DevOps API documentation and enhanced tests to verify non-empty values.