### PR TITLE
fix: allow parameterless tools to be called without arguments

### DIFF
--- a/src/server.spec.e2e.ts
+++ b/src/server.spec.e2e.ts
@@ -167,4 +167,45 @@ AZURE_DEVOPS_AUTH_METHOD=${authMethod}
       }
     });
   });
+
+  describe('Parameterless Tools', () => {
+    test('should call list_organizations without arguments', async () => {
+      // Act - call the tool without providing arguments
+      const result = await client.callTool({
+        name: 'list_organizations',
+        // No arguments provided
+      });
+
+      // Assert
+      expect(result).toBeDefined();
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content).toBeDefined();
+      expect(content.length).toBeGreaterThan(0);
+
+      // Verify we got a valid JSON response
+      const resultText = content[0].text;
+      const organizations = JSON.parse(resultText);
+      expect(Array.isArray(organizations)).toBe(true);
+    });
+
+    test('should call get_me without arguments', async () => {
+      // Act - call the tool without providing arguments
+      const result = await client.callTool({
+        name: 'get_me',
+        // No arguments provided
+      });
+
+      // Assert
+      expect(result).toBeDefined();
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content).toBeDefined();
+      expect(content.length).toBeGreaterThan(0);
+
+      // Verify we got a valid JSON response with user info
+      const resultText = content[0].text;
+      const userInfo = JSON.parse(resultText);
+      expect(userInfo).toHaveProperty('id');
+      expect(userInfo).toHaveProperty('displayName');
+    });
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,11 @@ function safeLog(message: string) {
 }
 
 /**
+ * Type definition for the Azure DevOps MCP Server
+ */
+export type AzureDevOpsServer = Server;
+
+/**
  * Create an Azure DevOps MCP Server
  *
  * @param config The Azure DevOps configuration
@@ -357,7 +362,14 @@ export function createAzureDevOpsServer(config: AzureDevOpsConfig): Server {
   // Register the CallTool request handler
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
-      if (!request.params.arguments) {
+      // Get a list of tools that don't require arguments
+      const parameterlessTools = ['get_me', 'list_organizations'];
+
+      // Only validate arguments for tools that require parameters
+      if (
+        !request.params.arguments &&
+        !parameterlessTools.includes(request.params.name)
+      ) {
         throw new AzureDevOpsValidationError('Arguments are required');
       }
 


### PR DESCRIPTION
This pull request introduces new tests and functionality to support parameterless tools in the Azure DevOps server. The changes include adding unit and end-to-end tests for the `get_me` and `list_organizations` tools and updating the server to handle these tools without requiring arguments.

### New tests for parameterless tools:
* [`src/server.spec.e2e.ts`](diffhunk://#diff-4c57badd5d811739d41b29197a7eb3b2a4dfd0d210e0d67ec2afdaed785fc1c0R170-R210): Added end-to-end tests to verify that `list_organizations` and `get_me` can be called without arguments and return valid JSON responses.
* [`src/server.spec.unit.ts`](diffhunk://#diff-0a8a21b3bec340d89ed4d2eac2f9317db2a0b1f75a05efe725d1f3434544f13eR1-R103): Added unit tests to verify that parameterless tools can be called without arguments and that tools requiring arguments throw appropriate errors.

### Server updates for parameterless tools:
* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L360-R367): Updated the `createAzureDevOpsServer` function to handle parameterless tools by checking if the tool name is in a predefined list before validating arguments.


Closes #146