### PR TITLE
feat(repositories): add get_all_repositories_tree tool

### DIFF
--- a/docs/tools/repositories.md
+++ b/docs/tools/repositories.md
@@ -414,3 +414,110 @@ In addition to using this tool, file content can also be accessed via resource U
 - `get_repository`: Get details of a specific repository
 - `get_repository_details`: Get detailed information about a repository including statistics and refs
 - `search_code`: Search for code across repositories in a project
+
+## get_all_repositories_tree
+
+Displays a hierarchical tree view of files and directories across multiple Azure DevOps repositories within a project, based on their default branches.
+
+### Description
+
+The `get_all_repositories_tree` tool provides a broad overview of file and directory structure across multiple repositories in a project. It uses a tree-like structure similar to the Unix `tree` command, with each repository's tree displayed sequentially.
+
+Key features:
+- Views multiple repositories at once
+- Filter repositories by name pattern
+- Filter files by pattern
+- Control depth to balance performance and detail
+- Shows directories and files in a hierarchical view
+- Provides statistics (count of files and directories)
+- Works with the default branch of each repository
+- Handles errors gracefully
+
+### Parameters
+
+```json
+{
+  "organizationId": "MyOrg",
+  "projectId": "MyProject",
+  "repositoryPattern": "API*",
+  "depth": 0, 
+  "pattern": "*.yaml"
+}
+```
+
+- `organizationId` (string, required): The ID or name of the Azure DevOps organization.
+- `projectId` (string, required): The ID or name of the project containing the repositories.
+- `repositoryPattern` (string, optional): Pattern to filter repositories by name (PowerShell wildcard).
+- `depth` (number, optional, default: 0): Maximum depth to traverse in each repository's file hierarchy. Use 0 for unlimited depth (more efficient server-side recursion), or a specific number (1-10) for limited depth.
+- `pattern` (string, optional): Pattern to filter files by name (PowerShell wildcard). Note: Directories are always shown regardless of this filter.
+
+### Response
+
+The response is a formatted ASCII tree showing the file and directory structure of each repository:
+
+```
+Repo-API-1/
+  |-- src/
+  |   |-- config.yaml
+  |   `-- utils/
+  `-- deploy.yaml
+1 directory, 2 files
+
+Repo-API-Gateway/
+  |-- charts/
+  |   `-- values.yaml
+  `-- README.md
+1 directory, 2 files
+
+Repo-Data-Service/
+  (Repository is empty or default branch not found)
+0 directories, 0 files
+```
+
+### Examples
+
+#### Basic Example - View All Repositories with Maximum Depth
+
+```javascript
+const result = await mcpClient.callTool('get_all_repositories_tree', {
+  organizationId: 'MyOrg',
+  projectId: 'MyProject'
+});
+console.log(result);
+```
+
+#### Filter Repositories by Name Pattern
+
+```javascript
+const result = await mcpClient.callTool('get_all_repositories_tree', {
+  organizationId: 'MyOrg',
+  projectId: 'MyProject',
+  repositoryPattern: 'API*'
+});
+console.log(result);
+```
+
+#### Limited Depth and File Pattern Filter
+
+```javascript
+const result = await mcpClient.callTool('get_all_repositories_tree', {
+  organizationId: 'MyOrg',
+  projectId: 'MyProject',
+  depth: 1,  // Only one level deep
+  pattern: '*.yaml'
+});
+console.log(result);
+```
+
+### Performance Considerations
+
+- For maximum depth (depth=0), the tool uses server-side recursion (VersionControlRecursionType.Full) which is more efficient for retrieving deep directory structures.
+- For limited depth (depth=1 to 10), the tool uses client-side recursion which is better for controlled exploration.
+- When viewing very large repositories, consider using a limited depth or file pattern to reduce response time.
+
+### Related Tools
+
+- `list_repositories`: Lists all repositories in a project (summary only)
+- `get_repository_details`: Gets detailed info about a single repository
+- `get_repository_tree`: Explores structure within a single repository (more detailed)
+- `get_file_content`: Gets content of a specific file

--- a/src/features/repositories/get-all-repositories-tree/__snapshots__/feature.spec.unit.ts.snap
+++ b/src/features/repositories/get-all-repositories-tree/__snapshots__/feature.spec.unit.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getAllRepositoriesTree should format complex repository tree structures correctly 1`] = `
+"complex-repo/
+  |-- docs/
+  |   |-- API.md
+  |   \`-- CONTRIBUTING.md
+  |-- src/
+  |   |-- assets/
+  |   |-- components/
+  |   |   |-- Button/
+  |   |   |   |-- Button.styles.ts
+  |   |   |   |-- Button.test.tsx
+  |   |   |   |-- Button.tsx
+  |   |   |   \`-- index.ts
+  |   |   \`-- Card/
+  |   |       \`-- Card.tsx
+  |   |-- utils/
+  |   |   |-- constants.ts
+  |   |   \`-- helpers.ts
+  |   |-- file_with_underscores.js
+  |   |-- file-with-dashes.js
+  |   \`-- index.ts
+  |-- tests/
+  |   |-- integration/
+  |   |-- unit/
+  |   |   \`-- example.test.js
+  |   \`-- setup.js
+  |-- .gitignore
+  |-- package.json
+  \`-- README.md
+10 directories, 18 files
+"
+`;
+
+exports[`getAllRepositoriesTree should format repository tree correctly 1`] = `
+"test-repo/
+  |-- src/
+  |   \`-- index.ts
+  \`-- README.md
+1 directories, 2 files
+"
+`;

--- a/src/features/repositories/get-all-repositories-tree/feature.spec.int.ts
+++ b/src/features/repositories/get-all-repositories-tree/feature.spec.int.ts
@@ -1,0 +1,137 @@
+import { getConnection } from '../../../server';
+import { shouldSkipIntegrationTest } from '../../../shared/test/test-helpers';
+import { getAllRepositoriesTree } from './feature';
+import { AzureDevOpsConfig } from '../../../shared/types';
+import { WebApi } from 'azure-devops-node-api';
+import { AuthenticationMethod } from '../../../shared/auth';
+
+// Skip tests if no PAT is available
+const hasPat = process.env.AZURE_DEVOPS_PAT && process.env.AZURE_DEVOPS_ORG_URL;
+const describeOrSkip = hasPat ? describe : describe.skip;
+
+describeOrSkip('getAllRepositoriesTree (Integration)', () => {
+  let connection: WebApi;
+  let config: AzureDevOpsConfig;
+  let projectId: string;
+  let orgId: string;
+
+  beforeAll(async () => {
+    if (shouldSkipIntegrationTest()) {
+      return;
+    }
+
+    // Configuration values
+    config = {
+      organizationUrl: process.env.AZURE_DEVOPS_ORG_URL || '',
+      authMethod: AuthenticationMethod.PersonalAccessToken,
+      personalAccessToken: process.env.AZURE_DEVOPS_PAT || '',
+      defaultProject: process.env.AZURE_DEVOPS_DEFAULT_PROJECT || '',
+    };
+
+    // Use test project - should be defined in .env file
+    projectId =
+      process.env.AZURE_DEVOPS_TEST_PROJECT_ID ||
+      process.env.AZURE_DEVOPS_DEFAULT_PROJECT ||
+      '';
+
+    // Extract organization ID from URL
+    const url = new URL(config.organizationUrl);
+    const pathParts = url.pathname.split('/').filter(Boolean);
+    orgId = pathParts[0] || '';
+
+    // Get Azure DevOps connection
+    connection = await getConnection(config);
+
+    // Skip tests if no project ID is set
+    if (!projectId) {
+      console.warn('Skipping integration tests: No test project ID set');
+    }
+  }, 30000);
+
+  // Skip all tests if integration tests are disabled
+  beforeEach(() => {
+    if (shouldSkipIntegrationTest()) {
+      jest.resetAllMocks();
+      return;
+    }
+  });
+
+  it('should retrieve tree for all repositories with maximum depth (default)', async () => {
+    // Skip test if no project ID or if integration tests are disabled
+    if (shouldSkipIntegrationTest() || !projectId) {
+      return;
+    }
+
+    const result = await getAllRepositoriesTree(connection, {
+      organizationId: orgId,
+      projectId: projectId,
+      // depth defaults to 0 (unlimited)
+    });
+
+    expect(result).toBeDefined();
+    expect(result.repositories).toBeDefined();
+    expect(Array.isArray(result.repositories)).toBe(true);
+    expect(result.repositories.length).toBeGreaterThan(0);
+
+    // Check that at least one repository has a tree
+    const repoWithTree = result.repositories.find((r) => r.tree.length > 0);
+    expect(repoWithTree).toBeDefined();
+
+    if (repoWithTree) {
+      // Verify that deep nesting is included (finding items with level > 2)
+      // Note: This might not always be true depending on repos, but there should be at least some nested items
+      const deepItems = repoWithTree.tree.filter((item) => item.level > 2);
+      expect(deepItems.length).toBeGreaterThan(0);
+
+      // Verify stats are correct
+      expect(repoWithTree.stats.directories).toBeGreaterThanOrEqual(0);
+      expect(repoWithTree.stats.files).toBeGreaterThan(0);
+      const dirCount = repoWithTree.tree.filter((item) => item.isFolder).length;
+      const fileCount = repoWithTree.tree.filter(
+        (item) => !item.isFolder,
+      ).length;
+      expect(repoWithTree.stats.directories).toBe(dirCount);
+      expect(repoWithTree.stats.files).toBe(fileCount);
+    }
+  }, 60000); // Longer timeout because max depth can take time
+
+  it('should retrieve tree for all repositories with limited depth (depth=1)', async () => {
+    // Skip test if no project ID or if integration tests are disabled
+    if (shouldSkipIntegrationTest() || !projectId) {
+      return;
+    }
+
+    const result = await getAllRepositoriesTree(connection, {
+      organizationId: orgId,
+      projectId: projectId,
+      depth: 1, // Only 1 level deep
+    });
+
+    expect(result).toBeDefined();
+    expect(result.repositories).toBeDefined();
+    expect(Array.isArray(result.repositories)).toBe(true);
+    expect(result.repositories.length).toBeGreaterThan(0);
+
+    // Check that at least one repository has a tree
+    const repoWithTree = result.repositories.find((r) => r.tree.length > 0);
+    expect(repoWithTree).toBeDefined();
+
+    if (repoWithTree) {
+      // Verify that only shallow nesting is included (all items should have level = 1)
+      const allItemsLevel1 = repoWithTree.tree.every(
+        (item) => item.level === 1,
+      );
+      expect(allItemsLevel1).toBe(true);
+
+      // Verify stats are correct
+      expect(repoWithTree.stats.directories).toBeGreaterThanOrEqual(0);
+      expect(repoWithTree.stats.files).toBeGreaterThanOrEqual(0);
+      const dirCount = repoWithTree.tree.filter((item) => item.isFolder).length;
+      const fileCount = repoWithTree.tree.filter(
+        (item) => !item.isFolder,
+      ).length;
+      expect(repoWithTree.stats.directories).toBe(dirCount);
+      expect(repoWithTree.stats.files).toBe(fileCount);
+    }
+  }, 30000);
+});

--- a/src/features/repositories/get-all-repositories-tree/feature.spec.unit.ts
+++ b/src/features/repositories/get-all-repositories-tree/feature.spec.unit.ts
@@ -1,0 +1,460 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  GitObjectType,
+  VersionControlRecursionType,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { getAllRepositoriesTree, formatRepositoryTree } from './feature';
+import { RepositoryTreeItem } from '../types';
+
+// Mock the Azure DevOps API
+jest.mock('azure-devops-node-api');
+
+describe('getAllRepositoriesTree', () => {
+  // Sample repositories
+  const mockRepos = [
+    {
+      id: 'repo1-id',
+      name: 'repo1',
+      defaultBranch: 'refs/heads/main',
+    },
+    {
+      id: 'repo2-id',
+      name: 'repo2',
+      defaultBranch: 'refs/heads/master',
+    },
+    {
+      id: 'repo3-id',
+      name: 'repo3-api',
+      defaultBranch: null, // No default branch
+    },
+  ];
+
+  // Sample files/folders for repo1 at root level
+  const mockRepo1RootItems = [
+    {
+      path: '/',
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/README.md',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/src',
+      isFolder: true,
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/package.json',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+  ];
+
+  // Sample files/folders for repo1 - src folder
+  const mockRepo1SrcItems = [
+    {
+      path: '/src',
+      isFolder: true,
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/src/index.ts',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/src/utils',
+      isFolder: true,
+      gitObjectType: GitObjectType.Tree,
+    },
+  ];
+
+  // Sample files/folders for repo1 with unlimited depth (what server would return for Full recursion)
+  const mockRepo1FullRecursionItems = [
+    {
+      path: '/',
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/README.md',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/src',
+      isFolder: true,
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/package.json',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/src/index.ts',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/src/utils',
+      isFolder: true,
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/src/utils/helper.ts',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/src/utils/constants.ts',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+  ];
+
+  // Sample files/folders for repo2
+  const mockRepo2RootItems = [
+    {
+      path: '/',
+      gitObjectType: GitObjectType.Tree,
+    },
+    {
+      path: '/README.md',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+    {
+      path: '/data.json',
+      isFolder: false,
+      gitObjectType: GitObjectType.Blob,
+    },
+  ];
+
+  let mockConnection: jest.Mocked<WebApi>;
+  let mockGitApi: any;
+
+  beforeEach(() => {
+    // Clear mocks
+    jest.clearAllMocks();
+
+    // Create mock GitApi
+    mockGitApi = {
+      getRepositories: jest.fn().mockResolvedValue(mockRepos),
+      getItems: jest
+        .fn()
+        .mockImplementation((repoId, _projectId, path, recursionLevel) => {
+          if (repoId === 'repo1-id') {
+            if (recursionLevel === VersionControlRecursionType.Full) {
+              return Promise.resolve(mockRepo1FullRecursionItems);
+            } else if (path === '/') {
+              return Promise.resolve(mockRepo1RootItems);
+            } else if (path === '/src') {
+              return Promise.resolve(mockRepo1SrcItems);
+            }
+          } else if (repoId === 'repo2-id') {
+            if (recursionLevel === VersionControlRecursionType.Full) {
+              return Promise.resolve(mockRepo2RootItems);
+            } else if (path === '/') {
+              return Promise.resolve(mockRepo2RootItems);
+            }
+          }
+          return Promise.resolve([]);
+        }),
+    };
+
+    // Create mock connection
+    mockConnection = {
+      getGitApi: jest.fn().mockResolvedValue(mockGitApi),
+    } as unknown as jest.Mocked<WebApi>;
+  });
+
+  it('should return tree structures for multiple repositories with limited depth', async () => {
+    // Arrange
+    const options = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      depth: 2, // Limited depth
+    };
+
+    // Act
+    const result = await getAllRepositoriesTree(mockConnection, options);
+
+    // Assert
+    expect(mockGitApi.getRepositories).toHaveBeenCalledWith('testProject');
+    expect(result.repositories.length).toBe(3);
+
+    // Verify repo1 tree
+    const repo1 = result.repositories.find((r) => r.name === 'repo1');
+    expect(repo1).toBeDefined();
+    expect(repo1?.tree.length).toBeGreaterThan(0);
+    expect(repo1?.stats.directories).toBeGreaterThan(0);
+    expect(repo1?.stats.files).toBeGreaterThan(0);
+
+    // Verify repo2 tree
+    const repo2 = result.repositories.find((r) => r.name === 'repo2');
+    expect(repo2).toBeDefined();
+    expect(repo2?.tree.length).toBeGreaterThan(0);
+
+    // Verify repo3 has error (no default branch)
+    const repo3 = result.repositories.find((r) => r.name === 'repo3-api');
+    expect(repo3).toBeDefined();
+    expect(repo3?.error).toContain('No default branch found');
+
+    // Verify recursion level was set correctly
+    expect(mockGitApi.getItems).toHaveBeenCalledWith(
+      'repo1-id',
+      'testProject',
+      '/',
+      VersionControlRecursionType.OneLevel,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('should return tree structures with max depth using Full recursion', async () => {
+    // Arrange
+    const options = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      depth: 0, // Max depth
+    };
+
+    // Act
+    const result = await getAllRepositoriesTree(mockConnection, options);
+
+    // Assert
+    expect(mockGitApi.getRepositories).toHaveBeenCalledWith('testProject');
+    expect(result.repositories.length).toBe(3);
+
+    // Verify repo1 tree
+    const repo1 = result.repositories.find((r) => r.name === 'repo1');
+    expect(repo1).toBeDefined();
+    expect(repo1?.tree.length).toBeGreaterThan(0);
+    // Should include all items, including nested ones
+    expect(repo1?.tree.length).toBe(mockRepo1FullRecursionItems.length - 1); // -1 for root folder
+
+    // Verify recursion level was set correctly
+    expect(mockGitApi.getItems).toHaveBeenCalledWith(
+      'repo1-id',
+      'testProject',
+      '/',
+      VersionControlRecursionType.Full,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    // Verify all levels are represented
+    if (repo1) {
+      const level1Items = repo1.tree.filter((item) => item.level === 1);
+      const level2Items = repo1.tree.filter((item) => item.level === 2);
+      const level3Items = repo1.tree.filter((item) => item.level === 3);
+
+      // Verify we have items at level 1
+      expect(level1Items.length).toBeGreaterThan(0);
+
+      // Verify we have items at level 2 (src/something)
+      expect(level2Items.length).toBeGreaterThan(0);
+
+      // Check for level 3 items if they exist in our mock data
+      if (
+        mockRepo1FullRecursionItems.some((item) => {
+          const pathSegments = item.path.split('/').filter(Boolean);
+          return pathSegments.length >= 3;
+        })
+      ) {
+        expect(level3Items.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('should filter repositories by pattern', async () => {
+    // Arrange
+    const options = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      repositoryPattern: '*api*',
+      depth: 1,
+    };
+
+    // Act
+    const result = await getAllRepositoriesTree(mockConnection, options);
+
+    // Assert
+    expect(mockGitApi.getRepositories).toHaveBeenCalledWith('testProject');
+    expect(result.repositories.length).toBe(1);
+    expect(result.repositories[0].name).toBe('repo3-api');
+  });
+
+  it('should format repository tree correctly', () => {
+    // Arrange
+    const treeItems: RepositoryTreeItem[] = [
+      { name: 'src', path: '/src', isFolder: true, level: 1 },
+      { name: 'index.ts', path: '/src/index.ts', isFolder: false, level: 2 },
+      { name: 'README.md', path: '/README.md', isFolder: false, level: 1 },
+    ];
+    const stats = { directories: 1, files: 2 };
+
+    // Act
+    const formatted = formatRepositoryTree('test-repo', treeItems, stats);
+
+    // Assert
+    expect(formatted).toMatchSnapshot();
+  });
+
+  it('should format complex repository tree structures correctly', () => {
+    // Arrange
+    const treeItems: RepositoryTreeItem[] = [
+      // Root level files
+      { name: 'README.md', path: '/README.md', isFolder: false, level: 1 },
+      {
+        name: 'package.json',
+        path: '/package.json',
+        isFolder: false,
+        level: 1,
+      },
+      { name: '.gitignore', path: '/.gitignore', isFolder: false, level: 1 },
+
+      // Multiple folders at root level
+      { name: 'src', path: '/src', isFolder: true, level: 1 },
+      { name: 'tests', path: '/tests', isFolder: true, level: 1 },
+      { name: 'docs', path: '/docs', isFolder: true, level: 1 },
+
+      // Nested src folder structure
+      { name: 'components', path: '/src/components', isFolder: true, level: 2 },
+      { name: 'utils', path: '/src/utils', isFolder: true, level: 2 },
+      { name: 'index.ts', path: '/src/index.ts', isFolder: false, level: 2 },
+
+      // Deeply nested components
+      {
+        name: 'Button',
+        path: '/src/components/Button',
+        isFolder: true,
+        level: 3,
+      },
+      { name: 'Card', path: '/src/components/Card', isFolder: true, level: 3 },
+      {
+        name: 'Button.tsx',
+        path: '/src/components/Button/Button.tsx',
+        isFolder: false,
+        level: 4,
+      },
+      {
+        name: 'Button.styles.ts',
+        path: '/src/components/Button/Button.styles.ts',
+        isFolder: false,
+        level: 4,
+      },
+      {
+        name: 'Button.test.tsx',
+        path: '/src/components/Button/Button.test.tsx',
+        isFolder: false,
+        level: 4,
+      },
+      {
+        name: 'index.ts',
+        path: '/src/components/Button/index.ts',
+        isFolder: false,
+        level: 4,
+      },
+      {
+        name: 'Card.tsx',
+        path: '/src/components/Card/Card.tsx',
+        isFolder: false,
+        level: 4,
+      },
+
+      // Utils with files
+      {
+        name: 'helpers.ts',
+        path: '/src/utils/helpers.ts',
+        isFolder: false,
+        level: 3,
+      },
+      {
+        name: 'constants.ts',
+        path: '/src/utils/constants.ts',
+        isFolder: false,
+        level: 3,
+      },
+
+      // Empty folder
+      { name: 'assets', path: '/src/assets', isFolder: true, level: 2 },
+
+      // Files with special characters
+      {
+        name: 'file-with-dashes.js',
+        path: '/src/file-with-dashes.js',
+        isFolder: false,
+        level: 2,
+      },
+      {
+        name: 'file_with_underscores.js',
+        path: '/src/file_with_underscores.js',
+        isFolder: false,
+        level: 2,
+      },
+
+      // Folders in test directory
+      { name: 'unit', path: '/tests/unit', isFolder: true, level: 2 },
+      {
+        name: 'integration',
+        path: '/tests/integration',
+        isFolder: true,
+        level: 2,
+      },
+
+      // Files in test directories
+      { name: 'setup.js', path: '/tests/setup.js', isFolder: false, level: 2 },
+      {
+        name: 'example.test.js',
+        path: '/tests/unit/example.test.js',
+        isFolder: false,
+        level: 3,
+      },
+
+      // Files in docs
+      { name: 'API.md', path: '/docs/API.md', isFolder: false, level: 2 },
+      {
+        name: 'CONTRIBUTING.md',
+        path: '/docs/CONTRIBUTING.md',
+        isFolder: false,
+        level: 2,
+      },
+    ];
+
+    const stats = { directories: 10, files: 18 };
+
+    // Act
+    const formatted = formatRepositoryTree('complex-repo', treeItems, stats);
+
+    // Assert
+    expect(formatted).toMatchSnapshot();
+  });
+
+  it('should handle repository errors gracefully', async () => {
+    // Arrange
+    mockGitApi.getItems = jest.fn().mockRejectedValue(new Error('API error'));
+
+    const options = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      depth: 1,
+    };
+
+    // Act
+    const result = await getAllRepositoriesTree(mockConnection, options);
+
+    // Assert
+    expect(result.repositories.length).toBe(3);
+    const repo1 = result.repositories.find((r) => r.name === 'repo1');
+    expect(repo1?.error).toBeDefined();
+  });
+});

--- a/src/features/repositories/get-all-repositories-tree/feature.ts
+++ b/src/features/repositories/get-all-repositories-tree/feature.ts
@@ -1,0 +1,457 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  GitVersionType,
+  VersionControlRecursionType,
+  GitItem,
+  GitObjectType,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { minimatch } from 'minimatch';
+import { AzureDevOpsError } from '../../../shared/errors';
+import {
+  GetAllRepositoriesTreeOptions,
+  AllRepositoriesTreeResponse,
+  RepositoryTreeResponse,
+  RepositoryTreeItem,
+  GitRepository,
+} from '../types';
+
+/**
+ * Get tree view of files/directories across multiple repositories
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for getting repository tree
+ * @returns Tree structure for each repository
+ */
+export async function getAllRepositoriesTree(
+  connection: WebApi,
+  options: GetAllRepositoriesTreeOptions,
+): Promise<AllRepositoriesTreeResponse> {
+  try {
+    const gitApi = await connection.getGitApi();
+    let repositories: GitRepository[] = [];
+
+    // Get all repositories in the project
+    repositories = await gitApi.getRepositories(options.projectId);
+
+    // Filter repositories by name pattern if specified
+    if (options.repositoryPattern) {
+      repositories = repositories.filter((repo) =>
+        minimatch(repo.name || '', options.repositoryPattern || '*'),
+      );
+    }
+
+    // Initialize results array
+    const results: RepositoryTreeResponse[] = [];
+
+    // Process each repository
+    for (const repo of repositories) {
+      try {
+        // Get default branch ref
+        const defaultBranch = repo.defaultBranch;
+        if (!defaultBranch) {
+          // Skip repositories with no default branch
+          results.push({
+            name: repo.name || 'Unknown',
+            tree: [],
+            stats: { directories: 0, files: 0 },
+            error: 'No default branch found',
+          });
+          continue;
+        }
+
+        // Clean the branch name (remove refs/heads/ prefix)
+        const branchRef = defaultBranch.replace('refs/heads/', '');
+
+        // Initialize tree items array and counters
+        const treeItems: RepositoryTreeItem[] = [];
+        const stats = { directories: 0, files: 0 };
+
+        // Determine the recursion level and processing approach
+        const depth = options.depth !== undefined ? options.depth : 0; // Default to 0 (max depth)
+
+        if (depth === 0) {
+          // For max depth (0), use server-side recursion for better performance
+          const allItems = await gitApi.getItems(
+            repo.id || '',
+            options.projectId,
+            '/',
+            VersionControlRecursionType.Full, // Use full recursion
+            true,
+            false,
+            false,
+            false,
+            {
+              version: branchRef,
+              versionType: GitVersionType.Branch,
+            },
+          );
+
+          // Filter out the root item itself and bad items
+          const itemsToProcess = allItems.filter(
+            (item) =>
+              item.path !== '/' && item.gitObjectType !== GitObjectType.Bad,
+          );
+
+          // Process all items at once (they're already retrieved recursively)
+          processItemsNonRecursive(
+            itemsToProcess,
+            treeItems,
+            stats,
+            options.pattern,
+          );
+        } else {
+          // For limited depth, use the regular recursive approach
+          // Get items at the root level
+          const rootItems = await gitApi.getItems(
+            repo.id || '',
+            options.projectId,
+            '/',
+            VersionControlRecursionType.OneLevel,
+            true,
+            false,
+            false,
+            false,
+            {
+              version: branchRef,
+              versionType: GitVersionType.Branch,
+            },
+          );
+
+          // Filter out the root item itself and bad items
+          const itemsToProcess = rootItems.filter(
+            (item) =>
+              item.path !== '/' && item.gitObjectType !== GitObjectType.Bad,
+          );
+
+          // Process the root items and their children (up to specified depth)
+          await processItems(
+            gitApi,
+            repo.id || '',
+            options.projectId,
+            itemsToProcess,
+            branchRef,
+            treeItems,
+            stats,
+            1,
+            depth,
+            options.pattern,
+          );
+        }
+
+        // Add repository tree to results
+        results.push({
+          name: repo.name || 'Unknown',
+          tree: treeItems,
+          stats,
+        });
+      } catch (repoError) {
+        // Handle errors for individual repositories
+        results.push({
+          name: repo.name || 'Unknown',
+          tree: [],
+          stats: { directories: 0, files: 0 },
+          error: `Error processing repository: ${repoError instanceof Error ? repoError.message : String(repoError)}`,
+        });
+      }
+    }
+
+    return { repositories: results };
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to get repository tree: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Process items non-recursively when they're already retrieved with VersionControlRecursionType.Full
+ */
+function processItemsNonRecursive(
+  items: GitItem[],
+  result: RepositoryTreeItem[],
+  stats: { directories: number; files: number },
+  pattern?: string,
+): void {
+  // Sort items (folders first, then by path)
+  const sortedItems = [...items].sort((a, b) => {
+    if (a.isFolder === b.isFolder) {
+      return (a.path || '').localeCompare(b.path || '');
+    }
+    return a.isFolder ? -1 : 1;
+  });
+
+  for (const item of sortedItems) {
+    const name = item.path?.split('/').pop() || '';
+    const path = item.path || '';
+    const isFolder = !!item.isFolder;
+
+    // Skip the root folder
+    if (path === '/') {
+      continue;
+    }
+
+    // Calculate level from path segments
+    // Remove leading '/' then count segments
+    // For paths like:
+    // /README.md -> ["README.md"] -> length 1 -> level 1
+    // /src/index.ts -> ["src", "index.ts"] -> length 2 -> level 2
+    // /src/utils/helper.ts -> ["src", "utils", "helper.ts"] -> length 3 -> level 3
+    const pathSegments = path.replace(/^\//, '').split('/');
+    const level = pathSegments.length;
+
+    // Filter files based on pattern (if specified)
+    if (!isFolder && pattern && !minimatch(name, pattern)) {
+      continue;
+    }
+
+    // Add item to results
+    result.push({
+      name,
+      path,
+      isFolder,
+      level,
+    });
+
+    // Update counters
+    if (isFolder) {
+      stats.directories++;
+    } else {
+      stats.files++;
+    }
+  }
+}
+
+/**
+ * Process items recursively up to the specified depth
+ */
+async function processItems(
+  gitApi: any,
+  repoId: string,
+  projectId: string,
+  items: GitItem[],
+  branchRef: string,
+  result: RepositoryTreeItem[],
+  stats: { directories: number; files: number },
+  currentDepth: number,
+  maxDepth: number,
+  pattern?: string,
+): Promise<void> {
+  // Sort items (directories first, then files)
+  const sortedItems = [...items].sort((a, b) => {
+    if (a.isFolder === b.isFolder) {
+      return (a.path || '').localeCompare(b.path || '');
+    }
+    return a.isFolder ? -1 : 1;
+  });
+
+  for (const item of sortedItems) {
+    const name = item.path?.split('/').pop() || '';
+    const path = item.path || '';
+    const isFolder = !!item.isFolder;
+
+    // Filter files based on pattern (if specified)
+    if (!isFolder && pattern && !minimatch(name, pattern)) {
+      continue;
+    }
+
+    // Add item to results
+    result.push({
+      name,
+      path,
+      isFolder,
+      level: currentDepth,
+    });
+
+    // Update counters
+    if (isFolder) {
+      stats.directories++;
+    } else {
+      stats.files++;
+    }
+
+    // Recursively process folders if not yet at max depth
+    if (isFolder && currentDepth < maxDepth) {
+      try {
+        const childItems = await gitApi.getItems(
+          repoId,
+          projectId,
+          path,
+          VersionControlRecursionType.OneLevel,
+          true,
+          false,
+          false,
+          false,
+          {
+            version: branchRef,
+            versionType: GitVersionType.Branch,
+          },
+        );
+
+        // Filter out the parent folder itself and bad items
+        const itemsToProcess = childItems.filter(
+          (child: GitItem) =>
+            child.path !== path && child.gitObjectType !== GitObjectType.Bad,
+        );
+
+        // Process child items
+        await processItems(
+          gitApi,
+          repoId,
+          projectId,
+          itemsToProcess,
+          branchRef,
+          result,
+          stats,
+          currentDepth + 1,
+          maxDepth,
+          pattern,
+        );
+      } catch (error) {
+        // Ignore errors in child items and continue with siblings
+        console.error(`Error processing folder ${path}: ${error}`);
+      }
+    }
+  }
+}
+
+/**
+ * Convert the tree items to a formatted ASCII string representation
+ *
+ * @param repoName Repository name
+ * @param items Tree items
+ * @param stats Statistics about files and directories
+ * @returns Formatted ASCII string
+ */
+export function formatRepositoryTree(
+  repoName: string,
+  items: RepositoryTreeItem[],
+  stats: { directories: number; files: number },
+  error?: string,
+): string {
+  let output = `${repoName}/\n`;
+
+  if (error) {
+    output += `  (${error})\n`;
+  } else if (items.length === 0) {
+    output += '  (Repository is empty or default branch not found)\n';
+  } else {
+    // Sort items by path to ensure proper sequence
+    const sortedItems = [...items].sort((a, b) => {
+      // Sort by level first
+      if (a.level !== b.level) {
+        return a.level - b.level;
+      }
+      // Then folders before files
+      if (a.isFolder !== b.isFolder) {
+        return a.isFolder ? -1 : 1;
+      }
+      // Then alphabetically
+      return a.path.localeCompare(b.path);
+    });
+
+    // Create a structured tree representation
+    const tree = createTreeStructure(sortedItems);
+
+    // Format the tree starting from the root
+    output += formatTree(tree, '  ');
+  }
+
+  // Add summary line
+  output += `${stats.directories} directories, ${stats.files} files\n`;
+
+  return output;
+}
+
+/**
+ * Create a structured tree from the flat list of items
+ */
+function createTreeStructure(items: RepositoryTreeItem[]): TreeNode {
+  const root: TreeNode = {
+    name: '',
+    path: '',
+    isFolder: true,
+    children: [],
+  };
+
+  // Map to track all nodes by path
+  const nodeMap: Record<string, TreeNode> = { '': root };
+
+  // First create all nodes
+  for (const item of items) {
+    nodeMap[item.path] = {
+      name: item.name,
+      path: item.path,
+      isFolder: item.isFolder,
+      children: [],
+    };
+  }
+
+  // Then build the hierarchy
+  for (const item of items) {
+    if (item.path === '/') continue;
+
+    const node = nodeMap[item.path];
+    const lastSlashIndex = item.path.lastIndexOf('/');
+
+    // For root level items, the parent path is empty
+    const parentPath =
+      lastSlashIndex <= 0 ? '' : item.path.substring(0, lastSlashIndex);
+
+    // Get parent node (defaults to root if parent not found)
+    const parent = nodeMap[parentPath] || root;
+
+    // Add this node as a child of its parent
+    parent.children.push(node);
+  }
+
+  return root;
+}
+
+/**
+ * Format a tree structure into an ASCII tree representation
+ */
+function formatTree(node: TreeNode, indent: string): string {
+  if (!node.children.length) return '';
+
+  let output = '';
+
+  // Sort the children: folders first, then alphabetically
+  const children = [...node.children].sort((a, b) => {
+    if (a.isFolder !== b.isFolder) {
+      return a.isFolder ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  // Format each child node
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const isLast = i === children.length - 1;
+    const connector = isLast ? '`-- ' : '|-- ';
+    const childIndent = isLast ? '    ' : '|   ';
+
+    // Add the node itself
+    const suffix = child.isFolder ? '/' : '';
+    output += `${indent}${connector}${child.name}${suffix}\n`;
+
+    // Recursively add its children
+    if (child.children.length > 0) {
+      output += formatTree(child, indent + childIndent);
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Tree node interface for hierarchical representation
+ */
+interface TreeNode {
+  name: string;
+  path: string;
+  isFolder: boolean;
+  children: TreeNode[];
+}

--- a/src/features/repositories/get-all-repositories-tree/index.ts
+++ b/src/features/repositories/get-all-repositories-tree/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/repositories/get-all-repositories-tree/schema.ts
+++ b/src/features/repositories/get-all-repositories-tree/schema.ts
@@ -1,0 +1,4 @@
+import { GetAllRepositoriesTreeSchema } from '../schemas';
+
+// Export with explicit name to avoid conflicts
+export { GetAllRepositoriesTreeSchema };

--- a/src/features/repositories/get-file-content/schema.ts
+++ b/src/features/repositories/get-file-content/schema.ts
@@ -1,16 +1,4 @@
-import { z } from 'zod';
-import { GitVersionType } from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { GetFileContentSchema } from '../schemas';
 
-export const GetFileContentSchema = z.object({
-  projectId: z.string().describe('The ID or name of the project'),
-  repositoryId: z.string().describe('The ID or name of the repository'),
-  path: z.string().describe('The path to the file or directory'),
-  versionType: z
-    .nativeEnum(GitVersionType)
-    .optional()
-    .describe('The type of version (branch, tag, or commit)'),
-  version: z
-    .string()
-    .optional()
-    .describe('The name of the branch or tag, or the SHA-1 hash of the commit'),
-});
+// Export with explicit name to avoid conflicts
+export { GetFileContentSchema };

--- a/src/features/repositories/index.ts
+++ b/src/features/repositories/index.ts
@@ -7,3 +7,4 @@ export * from './get-repository';
 export * from './get-repository-details';
 export * from './list-repositories';
 export * from './get-file-content';
+export * from './get-all-repositories-tree';

--- a/src/features/repositories/schemas.ts
+++ b/src/features/repositories/schemas.ts
@@ -46,3 +46,56 @@ export const ListRepositoriesSchema = z.object({
     .optional()
     .describe('Whether to include reference links'),
 });
+
+/**
+ * Schema for getting file content
+ */
+export const GetFileContentSchema = z.object({
+  projectId: z.string().describe('The ID or name of the project'),
+  repositoryId: z.string().describe('The ID or name of the repository'),
+  path: z
+    .string()
+    .optional()
+    .default('/')
+    .describe('Path to the file or folder'),
+  version: z
+    .string()
+    .optional()
+    .describe('The version (branch, tag, or commit) to get content from'),
+  versionType: z
+    .enum(['branch', 'commit', 'tag'])
+    .optional()
+    .describe('Type of version specified (branch, commit, or tag)'),
+});
+
+/**
+ * Schema for getting all repositories tree structure
+ */
+export const GetAllRepositoriesTreeSchema = z.object({
+  organizationId: z
+    .string()
+    .describe('The ID or name of the Azure DevOps organization'),
+  projectId: z.string().describe('The ID or name of the project'),
+  repositoryPattern: z
+    .string()
+    .optional()
+    .describe(
+      'Repository name pattern (PowerShell wildcard) to filter which repositories are included',
+    ),
+  depth: z
+    .number()
+    .int()
+    .min(0)
+    .max(10)
+    .optional()
+    .default(0)
+    .describe(
+      'Maximum depth to traverse within each repository (0 = unlimited)',
+    ),
+  pattern: z
+    .string()
+    .optional()
+    .describe(
+      'File pattern (PowerShell wildcard) to filter files by within each repository',
+    ),
+});

--- a/src/features/repositories/types.ts
+++ b/src/features/repositories/types.ts
@@ -2,6 +2,7 @@ import {
   GitRepository,
   GitBranchStats,
   GitRef,
+  GitItem,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 
 /**
@@ -38,5 +39,46 @@ export interface RepositoryDetails {
   };
 }
 
+/**
+ * Options for getting all repositories tree
+ */
+export interface GetAllRepositoriesTreeOptions {
+  organizationId: string;
+  projectId: string;
+  repositoryPattern?: string;
+  depth?: number;
+  pattern?: string;
+}
+
+/**
+ * Repository tree item representation for output
+ */
+export interface RepositoryTreeItem {
+  name: string;
+  path: string;
+  isFolder: boolean;
+  level: number;
+}
+
+/**
+ * Repository tree response for a single repository
+ */
+export interface RepositoryTreeResponse {
+  name: string;
+  tree: RepositoryTreeItem[];
+  stats: {
+    directories: number;
+    files: number;
+  };
+  error?: string;
+}
+
+/**
+ * Complete all repositories tree response
+ */
+export interface AllRepositoriesTreeResponse {
+  repositories: RepositoryTreeResponse[];
+}
+
 // Re-export GitRepository type for convenience
-export type { GitRepository, GitBranchStats, GitRef };
+export type { GitRepository, GitBranchStats, GitRef, GitItem };


### PR DESCRIPTION
Closes #150. This PR adds the get_all_repositories_tree tool that displays a hierarchical tree view of files and directories across multiple Azure DevOps repositories within a project, based on their default branches. The implementation follows the specifications in issue #150 and supports filtering by repository name pattern and file pattern, as well as limiting the traversal depth.