### PR TITLE
feat(wikis): implement `get_wikis` tool

### DIFF
--- a/src/features/wikis/get-wikis/feature.spec.int.ts
+++ b/src/features/wikis/get-wikis/feature.spec.int.ts
@@ -1,0 +1,77 @@
+import { WebApi } from 'azure-devops-node-api';
+import { getWikis } from './feature';
+import { getConnection } from '../../../server';
+import { AzureDevOpsConfig } from '../../../shared/types';
+import { AuthenticationMethod } from '../../../shared/auth';
+
+// Skip tests if not in integration test environment
+const runTests = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+// These tests require a valid Azure DevOps connection
+// They are skipped by default and only run when RUN_INTEGRATION_TESTS is set
+(runTests ? describe : describe.skip)('getWikis (Integration)', () => {
+  let connection: WebApi;
+  const projectId = process.env.AZURE_DEVOPS_TEST_PROJECT || '';
+
+  beforeAll(async () => {
+    // Skip setup if tests are skipped
+    if (!runTests) return;
+
+    // Ensure we have required environment variables
+    if (!process.env.AZURE_DEVOPS_ORG_URL) {
+      throw new Error('AZURE_DEVOPS_ORG_URL environment variable is required');
+    }
+
+    if (!projectId) {
+      throw new Error(
+        'AZURE_DEVOPS_TEST_PROJECT environment variable is required',
+      );
+    }
+
+    // Create connection
+    const config: AzureDevOpsConfig = {
+      organizationUrl: process.env.AZURE_DEVOPS_ORG_URL,
+      authMethod:
+        (process.env.AZURE_DEVOPS_AUTH_METHOD as AuthenticationMethod) ||
+        AuthenticationMethod.PersonalAccessToken,
+      personalAccessToken: process.env.AZURE_DEVOPS_PAT,
+    };
+
+    connection = await getConnection(config);
+  }, 30000);
+
+  it('should get wikis from a project', async () => {
+    // Skip if tests are skipped
+    if (!runTests) return;
+
+    const result = await getWikis(connection, { projectId });
+
+    // Verify the result structure (even if no wikis exist)
+    expect(Array.isArray(result)).toBe(true);
+
+    // If there are wikis, verify their structure
+
+    const firstWiki = result[0];
+    expect(firstWiki.id).toBeDefined();
+    expect(firstWiki.name).toBeDefined();
+    expect(firstWiki.url).toBeDefined();
+  }, 30000);
+
+  it('should get wikis from the organization when projectId is not provided', async () => {
+    // Skip if tests are skipped
+    if (!runTests) return;
+
+    const result = await getWikis(connection, {});
+
+    // Verify the result structure
+    expect(Array.isArray(result)).toBe(true);
+
+    // Organization-level query should typically return more wikis or the same
+    // number as a project-level query, unless the project has no wikis
+
+    const firstWiki = result[0];
+    expect(firstWiki.id).toBeDefined();
+    expect(firstWiki.name).toBeDefined();
+    expect(firstWiki.url).toBeDefined();
+  }, 30000);
+});

--- a/src/features/wikis/get-wikis/feature.spec.unit.ts
+++ b/src/features/wikis/get-wikis/feature.spec.unit.ts
@@ -1,0 +1,106 @@
+import { WebApi } from 'azure-devops-node-api';
+import { WikiV2 } from 'azure-devops-node-api/interfaces/WikiInterfaces';
+import {
+  AzureDevOpsResourceNotFoundError,
+  AzureDevOpsError,
+} from '../../../shared/errors';
+import { getWikis } from './feature';
+
+// Mock the Azure DevOps WebApi
+jest.mock('azure-devops-node-api');
+
+describe('getWikis unit', () => {
+  // Mock WikiApi client
+  const mockWikiApi = {
+    getAllWikis: jest.fn(),
+  };
+
+  // Mock WebApi connection
+  const mockConnection = {
+    getWikiApi: jest.fn().mockResolvedValue(mockWikiApi),
+  } as unknown as WebApi;
+
+  beforeEach(() => {
+    // Clear mock calls between tests
+    jest.clearAllMocks();
+  });
+
+  test('should return wikis for a project', async () => {
+    // Mock data
+    const mockWikis: WikiV2[] = [
+      {
+        id: 'wiki1',
+        name: 'Project Wiki',
+        mappedPath: '/',
+        remoteUrl: 'https://example.com/wiki1',
+        url: 'https://dev.azure.com/org/project/_wiki/wikis/wiki1',
+      },
+      {
+        id: 'wiki2',
+        name: 'Code Wiki',
+        mappedPath: '/docs',
+        remoteUrl: 'https://example.com/wiki2',
+        url: 'https://dev.azure.com/org/project/_wiki/wikis/wiki2',
+      },
+    ];
+
+    // Setup mock responses
+    mockWikiApi.getAllWikis.mockResolvedValue(mockWikis);
+
+    // Call the function
+    const result = await getWikis(mockConnection, {
+      projectId: 'testProject',
+    });
+
+    // Assertions
+    expect(mockConnection.getWikiApi).toHaveBeenCalledTimes(1);
+    expect(mockWikiApi.getAllWikis).toHaveBeenCalledWith('testProject');
+    expect(result).toEqual(mockWikis);
+    expect(result.length).toBe(2);
+  });
+
+  test('should return empty array when no wikis are found', async () => {
+    // Setup mock responses
+    mockWikiApi.getAllWikis.mockResolvedValue([]);
+
+    // Call the function
+    const result = await getWikis(mockConnection, {
+      projectId: 'projectWithNoWikis',
+    });
+
+    // Assertions
+    expect(mockConnection.getWikiApi).toHaveBeenCalledTimes(1);
+    expect(mockWikiApi.getAllWikis).toHaveBeenCalledWith('projectWithNoWikis');
+    expect(result).toEqual([]);
+  });
+
+  test('should handle API errors gracefully', async () => {
+    // Setup mock to throw an error
+    const mockError = new Error('API error occurred');
+    mockWikiApi.getAllWikis.mockRejectedValue(mockError);
+
+    // Call the function and expect it to throw
+    await expect(
+      getWikis(mockConnection, { projectId: 'testProject' }),
+    ).rejects.toThrow(AzureDevOpsError);
+
+    // Assertions
+    expect(mockConnection.getWikiApi).toHaveBeenCalledTimes(1);
+    expect(mockWikiApi.getAllWikis).toHaveBeenCalledWith('testProject');
+  });
+
+  test('should throw ResourceNotFoundError for non-existent project', async () => {
+    // Setup mock to throw an error with specific resource not found message
+    const mockError = new Error('The resource cannot be found');
+    mockWikiApi.getAllWikis.mockRejectedValue(mockError);
+
+    // Call the function and expect it to throw a specific error type
+    await expect(
+      getWikis(mockConnection, { projectId: 'nonExistentProject' }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
+
+    // Assertions
+    expect(mockConnection.getWikiApi).toHaveBeenCalledTimes(1);
+    expect(mockWikiApi.getAllWikis).toHaveBeenCalledWith('nonExistentProject');
+  });
+});

--- a/src/features/wikis/get-wikis/feature.ts
+++ b/src/features/wikis/get-wikis/feature.ts
@@ -1,0 +1,69 @@
+import { WebApi } from 'azure-devops-node-api';
+import { WikiV2 } from 'azure-devops-node-api/interfaces/WikiInterfaces';
+import {
+  AzureDevOpsError,
+  AzureDevOpsResourceNotFoundError,
+} from '../../../shared/errors';
+
+/**
+ * Options for getting wikis
+ */
+export interface GetWikisOptions {
+  /**
+   * The ID or name of the organization
+   * If not provided, the default organization will be used
+   */
+  organizationId?: string;
+
+  /**
+   * The ID or name of the project
+   * If not provided, the wikis from all projects will be returned
+   */
+  projectId?: string;
+}
+
+/**
+ * Get wikis in a project or organization
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for getting wikis
+ * @returns List of wikis
+ */
+export async function getWikis(
+  connection: WebApi,
+  options: GetWikisOptions,
+): Promise<WikiV2[]> {
+  try {
+    // Get the Wiki API client
+    const wikiApi = await connection.getWikiApi();
+
+    // If a projectId is provided, get wikis for that specific project
+    // Otherwise, get wikis for the entire organization
+    const { projectId } = options;
+
+    const wikis = await wikiApi.getAllWikis(projectId);
+
+    return wikis || [];
+  } catch (error) {
+    // Handle resource not found errors specifically
+    if (
+      error instanceof Error &&
+      error.message &&
+      error.message.includes('The resource cannot be found')
+    ) {
+      throw new AzureDevOpsResourceNotFoundError(
+        `Resource not found: ${options.projectId ? `Project '${options.projectId}'` : 'Organization'}`,
+      );
+    }
+
+    // If it's already an AzureDevOpsError, rethrow it
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+
+    // Otherwise, wrap it in a generic error
+    throw new AzureDevOpsError(
+      `Failed to get wikis: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/wikis/get-wikis/handler.ts
+++ b/src/features/wikis/get-wikis/handler.ts
@@ -1,0 +1,33 @@
+import { WebApi } from 'azure-devops-node-api';
+import { GetWikisSchema } from './schema';
+import { getWikis } from './feature';
+import { defaultOrg, defaultProject } from '../../../utils/environment';
+
+/**
+ * Handler for the "get_wikis" tool
+ *
+ * This handler retrieves wikis in a specified project or organization.
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param toolParams The parameters for the tool call
+ * @returns List of wikis
+ */
+export const getWikisHandler = async (
+  connection: WebApi,
+  toolParams: Record<string, unknown>,
+) => {
+  // Parse and validate the parameters
+  const params = GetWikisSchema.parse(toolParams);
+
+  // Use default organization ID if not provided
+  const organizationId = params.organizationId || defaultOrg;
+
+  // Call the feature implementation
+  const wikis = await getWikis(connection, {
+    organizationId,
+    projectId: params.projectId ?? defaultProject,
+  });
+
+  // Return the wikis
+  return wikis;
+};

--- a/src/features/wikis/get-wikis/index.ts
+++ b/src/features/wikis/get-wikis/index.ts
@@ -1,0 +1,2 @@
+export { getWikisHandler } from './handler';
+export { GetWikisSchema } from './schema';

--- a/src/features/wikis/get-wikis/schema.ts
+++ b/src/features/wikis/get-wikis/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import { defaultProject, defaultOrg } from '../../../utils/environment';
+
+/**
+ * Schema for listing wikis in an Azure DevOps project or organization
+ */
+export const GetWikisSchema = z.object({
+  organizationId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  projectId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+});

--- a/src/features/wikis/index.ts
+++ b/src/features/wikis/index.ts
@@ -1,0 +1,1 @@
+export { getWikisHandler, GetWikisSchema } from './get-wikis';

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,9 @@ import {
 
 import { GitVersionType } from 'azure-devops-node-api/interfaces/GitInterfaces';
 
+// Import wikis feature modules
+import { GetWikisSchema, getWikisHandler } from './features/wikis';
+
 // Create a safe console logging function that won't interfere with MCP protocol
 function safeLog(message: string) {
   process.stderr.write(`${message}\n`);
@@ -250,6 +253,12 @@ export function createAzureDevOpsServer(config: AzureDevOpsConfig): Server {
           name: 'create_pull_request',
           description: 'Create a new pull request',
           inputSchema: zodToJsonSchema(CreatePullRequestSchema),
+        },
+        // Wiki tools
+        {
+          name: 'get_wikis',
+          description: 'Get details of wikis in a project',
+          inputSchema: zodToJsonSchema(GetWikisSchema),
         },
       ],
     };
@@ -718,6 +727,15 @@ export function createAzureDevOpsServer(config: AzureDevOpsConfig): Server {
             args.repositoryId,
             args,
           );
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+
+        // Wiki tools
+        case 'get_wikis': {
+          const args = GetWikisSchema.parse(request.params.arguments);
+          const result = await getWikisHandler(connection, args);
           return {
             content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           };


### PR DESCRIPTION
This pull request introduces a new feature for retrieving wikis from Azure DevOps projects or organizations. It includes the implementation of the `getWikis` function, unit and integration tests, schema validation, and integration with the Azure DevOps server. Below are the key changes grouped by theme:

### Feature Implementation
* Added the `getWikis` function in `src/features/wikis/get-wikis/feature.ts` to fetch wikis from a specific project or organization using the Azure DevOps API. It handles errors and supports both project-level and organization-level queries.

### Testing
* Added unit tests in `src/features/wikis/get-wikis/feature.spec.unit.ts` to validate the behavior of the `getWikis` function, including handling API errors and resource not found scenarios.
* Added integration tests in `src/features/wikis/get-wikis/feature.spec.int.ts` to verify the `getWikis` function in a real Azure DevOps environment. These tests are conditionally executed based on environment variables.

### Schema and Handler
* Defined a schema for input validation in `src/features/wikis/get-wikis/schema.ts` using `zod`. The schema includes optional parameters for organization and project IDs with default values.
* Implemented the `getWikisHandler` in `src/features/wikis/get-wikis/handler.ts` to handle requests for retrieving wikis, using the schema for validation and the `getWikis` function for execution.

### Integration with Azure DevOps Server
* Registered the `get_wikis` tool in `src/server.ts`, including its schema and handler, enabling it to be called via the Azure DevOps server. [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R91-R93) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R257-R262) [[3]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R735-R743)

### Exports and Indexing
* Exported the `getWikisHandler` and `GetWikisSchema` in `src/features/wikis/get-wikis/index.ts` and `src/features/wikis/index.ts` for broader accessibility. [[1]](diffhunk://#diff-b3d534a1a681881f3ad0768d34bb58156fedef65cab7983481645d3498cb696dR1-R2) [[2]](diffhunk://#diff-8e84f88871e18ac2f91ca7f9ba7f9135c164b5c604374741c97d04530f97f603R1)