### PR TITLE
feat(wikis): implement `get_wiki_page` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ The Azure DevOps MCP server provides a variety of tools for interacting with Azu
 - get_pipeline: Get details of a specific pipeline
 - trigger_pipeline: Trigger a pipeline run with customizable parameters
 
+### Wiki Tools
+
+- `get_wikis`: List all wikis in a project
+- `get_wiki_page`: Get content of a specific wiki page as plain text
+
 For comprehensive documentation on all tools, see the [Tools Documentation](docs/tools/).
 
 ## Contributing

--- a/docs/tools/wiki.md
+++ b/docs/tools/wiki.md
@@ -1,0 +1,113 @@
+# Azure DevOps Wiki Tools
+
+This document describes the tools available for working with Azure DevOps wikis.
+
+## get_wikis
+
+Lists all wikis in a project or organization.
+
+### Description
+
+The `get_wikis` tool retrieves all wikis available in a specified Azure DevOps project or organization. This is useful for discovering which wikis are available before working with specific wiki pages.
+
+### Parameters
+
+- `organizationId` (optional): The ID or name of the organization. If not provided, the default organization from environment settings will be used.
+- `projectId` (optional): The ID or name of the project. If not provided, the default project from environment settings will be used.
+
+```json
+{
+  "organizationId": "MyOrganization",
+  "projectId": "MyProject"
+}
+```
+
+### Response
+
+The tool returns an array of wiki objects, each containing:
+
+- `id`: The unique identifier of the wiki
+- `name`: The name of the wiki
+- `url`: The URL of the wiki
+- Other wiki properties such as `remoteUrl` and `type`
+
+Example response:
+
+```json
+[
+  {
+    "id": "wiki1-id",
+    "name": "MyWiki",
+    "type": "projectWiki",
+    "url": "https://dev.azure.com/MyOrganization/MyProject/_wiki/wikis/MyWiki",
+    "remoteUrl": "https://dev.azure.com/MyOrganization/MyProject/_git/MyWiki"
+  }
+]
+```
+
+## get_wiki_page
+
+Gets the content of a specific wiki page.
+
+### Description
+
+The `get_wiki_page` tool retrieves the content of a specified wiki page as plain text. This is useful for viewing the content of wiki pages programmatically.
+
+### Parameters
+
+- `organizationId` (optional): The ID or name of the organization. If not provided, the default organization from environment settings will be used.
+- `projectId` (optional): The ID or name of the project. If not provided, the default project from environment settings will be used.
+- `wikiId` (required): The ID or name of the wiki containing the page.
+- `pagePath` (required): The path of the page within the wiki (e.g., "/Home" or "/Folder/Page").
+
+```json
+{
+  "organizationId": "MyOrganization",
+  "projectId": "MyProject",
+  "wikiId": "MyWiki",
+  "pagePath": "/Home"
+}
+```
+
+### Response
+
+The tool returns the content of the wiki page as a string in markdown format.
+
+Example response:
+
+```markdown
+# Welcome to the Wiki
+
+This is the home page of the wiki.
+
+## Getting Started
+
+Here are some links to help you get started:
+- [Documentation](/Documentation)
+- [Tutorials](/Tutorials)
+- [FAQ](/FAQ)
+```
+
+### Error Handling
+
+The tool may throw the following errors:
+
+- `AzureDevOpsResourceNotFoundError`: If the specified wiki or page does not exist
+- `AzureDevOpsPermissionError`: If the authenticated user does not have permission to access the wiki
+- General errors: If other unexpected errors occur during the request
+
+### Example Usage
+
+```typescript
+// Example MCP client call
+const result = await mcpClient.callTool('get_wiki_page', {
+  projectId: 'MyProject',
+  wikiId: 'MyWiki',
+  pagePath: '/Home'
+});
+console.log(result);
+```
+
+### Implementation Details
+
+This tool uses the Azure DevOps REST API to retrieve the wiki page content with the `Accept: text/plain` header to get the content directly in text format. The page path is properly encoded to handle spaces and special characters in the URL. 

--- a/src/features/wikis/get-wiki-page/feature.spec.int.ts
+++ b/src/features/wikis/get-wiki-page/feature.spec.int.ts
@@ -1,0 +1,66 @@
+import { getWikiPage } from './feature';
+
+// Skip tests if not in integration test environment
+const runTests = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+// These tests require a valid Azure DevOps connection
+// They are skipped by default and only run when RUN_INTEGRATION_TESTS is set
+(runTests ? describe : describe.skip)('getWikiPage (Integration)', () => {
+  const organizationId = process.env.AZURE_DEVOPS_TEST_ORG || '';
+  const projectId = process.env.AZURE_DEVOPS_TEST_PROJECT || '';
+  const wikiId = process.env.AZURE_DEVOPS_TEST_WIKI || '';
+
+  beforeAll(async () => {
+    // Skip setup if tests are skipped
+    if (!runTests) return;
+
+    // Ensure we have required environment variables
+    if (!process.env.AZURE_DEVOPS_ORG_URL) {
+      throw new Error('AZURE_DEVOPS_ORG_URL environment variable is required');
+    }
+
+    if (!projectId) {
+      throw new Error(
+        'AZURE_DEVOPS_TEST_PROJECT environment variable is required',
+      );
+    }
+
+    if (!wikiId) {
+      throw new Error(
+        'AZURE_DEVOPS_TEST_WIKI environment variable is required',
+      );
+    }
+  }, 30000);
+
+  it('should get a wiki page by path', async () => {
+    // Skip if tests are skipped
+    if (!runTests) return;
+
+    // Attempt to get the root wiki page
+    const result = await getWikiPage({
+      organizationId,
+      projectId,
+      wikiId,
+      pagePath: '/',
+    });
+
+    // Check that the result is a non-empty string
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('should throw when wiki page does not exist', async () => {
+    // Skip if tests are skipped
+    if (!runTests) return;
+
+    // Try to get a non-existent page
+    await expect(
+      getWikiPage({
+        organizationId,
+        projectId,
+        wikiId,
+        pagePath: '/This/Path/Should/Not/Exist/' + Date.now(),
+      }),
+    ).rejects.toThrow();
+  }, 30000);
+});

--- a/src/features/wikis/get-wiki-page/feature.spec.unit.ts
+++ b/src/features/wikis/get-wiki-page/feature.spec.unit.ts
@@ -1,0 +1,157 @@
+import axios from 'axios';
+import { getWikiPage, GetWikiPageOptions } from './feature';
+import {
+  AzureDevOpsResourceNotFoundError,
+  AzureDevOpsPermissionError,
+  AzureDevOpsError,
+} from '../../../shared/errors';
+
+// Mock Azure Identity
+jest.mock('@azure/identity', () => {
+  const mockGetToken = jest.fn().mockResolvedValue({ token: 'mock-token' });
+  return {
+    DefaultAzureCredential: jest.fn().mockImplementation(() => ({
+      getToken: mockGetToken,
+    })),
+    AzureCliCredential: jest.fn().mockImplementation(() => ({
+      getToken: mockGetToken,
+    })),
+  };
+});
+
+// Mock axios module
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock getAuthorizationHeader function
+jest.mock('./feature', () => {
+  const originalModule = jest.requireActual('./feature');
+  return {
+    ...originalModule,
+    getAuthorizationHeader: jest.fn().mockResolvedValue('Bearer mock-token'),
+  };
+});
+
+describe('getWikiPage unit', () => {
+  const mockWikiPageContent = 'Wiki page content text';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAxios.get.mockResolvedValue({
+      status: 200,
+      data: mockWikiPageContent,
+    });
+  });
+
+  it('should return wiki page content as text', async () => {
+    // Act
+    const options: GetWikiPageOptions = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      wikiId: 'testWiki',
+      pagePath: '/Home',
+    };
+
+    const result = await getWikiPage(options);
+
+    // Assert
+    expect(result).toBe(mockWikiPageContent);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://dev.azure.com/testOrg/testProject/_apis/wiki/wikis/testWiki/pages',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          'api-version': '7.0',
+          path: '/Home',
+        }),
+        headers: expect.objectContaining({
+          Accept: 'text/plain',
+          Authorization: 'Bearer mock-token',
+          'Content-Type': 'application/json',
+        }),
+        responseType: 'text',
+      }),
+    );
+  });
+
+  it('should properly encode wiki page path in URL', async () => {
+    // Act
+    const options: GetWikiPageOptions = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      wikiId: 'testWiki',
+      pagePath: '/Path with spaces/And special chars $&+,/:;=?@',
+    };
+
+    await getWikiPage(options);
+
+    // Assert
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://dev.azure.com/testOrg/testProject/_apis/wiki/wikis/testWiki/pages',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          path: '/Path%20with%20spaces/And%20special%20chars%20%24%26%2B%2C/%3A%3B%3D%3F%40',
+        }),
+      }),
+    );
+  });
+
+  it('should throw ResourceNotFoundError when wiki page is not found', async () => {
+    // Arrange
+    mockedAxios.get.mockRejectedValue({
+      response: {
+        status: 404,
+        data: { message: 'Page not found' },
+      },
+    });
+
+    // Act & Assert
+    const options: GetWikiPageOptions = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      wikiId: 'testWiki',
+      pagePath: '/NonExistentPage',
+    };
+
+    await expect(getWikiPage(options)).rejects.toThrow(
+      AzureDevOpsResourceNotFoundError,
+    );
+  });
+
+  it('should throw PermissionError when user lacks permissions', async () => {
+    // Arrange
+    mockedAxios.get.mockRejectedValue({
+      response: {
+        status: 403,
+        data: { message: 'Permission denied' },
+      },
+    });
+
+    // Act & Assert
+    const options: GetWikiPageOptions = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      wikiId: 'testWiki',
+      pagePath: '/RestrictedPage',
+    };
+
+    await expect(getWikiPage(options)).rejects.toThrow(
+      AzureDevOpsPermissionError,
+    );
+  });
+
+  it('should throw generic error for other failures', async () => {
+    // Arrange
+    mockedAxios.get.mockRejectedValue(new Error('Network error'));
+
+    // Act & Assert
+    const options: GetWikiPageOptions = {
+      organizationId: 'testOrg',
+      projectId: 'testProject',
+      wikiId: 'testWiki',
+      pagePath: '/AnyPage',
+    };
+
+    await expect(getWikiPage(options)).rejects.toThrow(AzureDevOpsError);
+  });
+});

--- a/src/features/wikis/get-wiki-page/feature.ts
+++ b/src/features/wikis/get-wiki-page/feature.ts
@@ -1,0 +1,160 @@
+import axios, { AxiosError } from 'axios';
+import { DefaultAzureCredential, AzureCliCredential } from '@azure/identity';
+import {
+  AzureDevOpsError,
+  AzureDevOpsResourceNotFoundError,
+  AzureDevOpsValidationError,
+  AzureDevOpsPermissionError,
+} from '../../../shared/errors';
+import { defaultOrg, defaultProject } from '../../../utils/environment';
+
+/**
+ * Options for getting a wiki page
+ */
+export interface GetWikiPageOptions {
+  /**
+   * The ID or name of the organization
+   * If not provided, the default organization will be used
+   */
+  organizationId?: string;
+
+  /**
+   * The ID or name of the project
+   * If not provided, the default project will be used
+   */
+  projectId?: string;
+
+  /**
+   * The ID or name of the wiki
+   */
+  wikiId: string;
+
+  /**
+   * The path of the page within the wiki
+   */
+  pagePath: string;
+}
+
+/**
+ * Get a wiki page from a wiki
+ *
+ * @param options Options for getting a wiki page
+ * @returns Wiki page content as text/plain
+ * @throws {AzureDevOpsResourceNotFoundError} When the wiki page is not found
+ * @throws {AzureDevOpsPermissionError} When the user does not have permission to access the wiki page
+ * @throws {AzureDevOpsError} When an error occurs while fetching the wiki page
+ */
+export async function getWikiPage(
+  options: GetWikiPageOptions,
+): Promise<string> {
+  const { organizationId, projectId, wikiId, pagePath } = options;
+
+  // Encode the page path, handling forward slashes properly
+  const encodedPagePath = encodeURIComponent(pagePath).replace(/%2F/g, '/');
+
+  // Construct the URL to fetch the wiki page
+  const baseUri = `https://dev.azure.com/${organizationId ?? defaultOrg}`;
+  const url = `${baseUri}/${projectId ?? defaultProject}/_apis/wiki/wikis/${wikiId}/pages`;
+  const params = {
+    'api-version': '7.0',
+    path: encodedPagePath,
+  };
+
+  try {
+    // Get authorization header
+    const authHeader = await getAuthorizationHeader();
+
+    // Make the API request
+    const response = await axios.get(url, {
+      params,
+      headers: {
+        Authorization: authHeader,
+        Accept: 'text/plain',
+        'Content-Type': 'application/json',
+      },
+      responseType: 'text',
+    });
+
+    // Return the page content
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError;
+
+    // Handle specific error cases
+    if (axiosError.response) {
+      const status = axiosError.response.status;
+      const errorMessage =
+        typeof axiosError.response.data === 'object' && axiosError.response.data
+          ? (axiosError.response.data as any).message || axiosError.message
+          : axiosError.message;
+
+      // Handle 404 Not Found
+      if (status === 404) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Wiki page not found: ${pagePath} in wiki ${wikiId}`,
+        );
+      }
+
+      // Handle 401 Unauthorized or 403 Forbidden
+      if (status === 401 || status === 403) {
+        throw new AzureDevOpsPermissionError(
+          `Permission denied to access wiki page: ${pagePath}`,
+        );
+      }
+
+      // Handle other error statuses
+      throw new AzureDevOpsError(`Failed to fetch wiki page: ${errorMessage}`);
+    }
+
+    // Handle network errors
+    throw new AzureDevOpsError(
+      `Network error when fetching wiki page: ${axiosError.message}`,
+    );
+  }
+}
+
+/**
+ * Get the authorization header for Azure DevOps API requests
+ *
+ * @returns The authorization header
+ */
+async function getAuthorizationHeader(): Promise<string> {
+  try {
+    // For PAT authentication, we can construct the header directly
+    if (
+      process.env.AZURE_DEVOPS_AUTH_METHOD?.toLowerCase() === 'pat' &&
+      process.env.AZURE_DEVOPS_PAT
+    ) {
+      // For PAT auth, we can construct the Basic auth header directly
+      const token = process.env.AZURE_DEVOPS_PAT;
+      const base64Token = Buffer.from(`:${token}`).toString('base64');
+      return `Basic ${base64Token}`;
+    }
+
+    // For Azure Identity / Azure CLI auth, we need to get a token
+    // using the Azure DevOps resource ID
+    // Choose the appropriate credential based on auth method
+    const credential =
+      process.env.AZURE_DEVOPS_AUTH_METHOD?.toLowerCase() === 'azure-cli'
+        ? new AzureCliCredential()
+        : new DefaultAzureCredential();
+
+    // Azure DevOps resource ID for token acquisition
+    const AZURE_DEVOPS_RESOURCE_ID = '499b84ac-1321-427f-aa17-267ca6975798';
+
+    // Get token for Azure DevOps
+    const token = await credential.getToken(
+      `${AZURE_DEVOPS_RESOURCE_ID}/.default`,
+    );
+
+    if (!token || !token.token) {
+      throw new Error('Failed to acquire token for Azure DevOps');
+    }
+
+    return `Bearer ${token.token}`;
+  } catch (error) {
+    throw new AzureDevOpsValidationError(
+      `Failed to get authorization header: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/wikis/get-wiki-page/index.ts
+++ b/src/features/wikis/get-wiki-page/index.ts
@@ -1,0 +1,2 @@
+export { getWikiPage } from './feature';
+export { GetWikiPageSchema } from './schema';

--- a/src/features/wikis/get-wiki-page/schema.ts
+++ b/src/features/wikis/get-wiki-page/schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+import { defaultProject, defaultOrg } from '../../../utils/environment';
+
+/**
+ * Schema for getting a wiki page from an Azure DevOps wiki
+ */
+export const GetWikiPageSchema = z.object({
+  organizationId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  projectId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  wikiId: z.string().describe('The ID or name of the wiki'),
+  pagePath: z.string().describe('The path of the page within the wiki'),
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,7 +89,8 @@ import {
 import { GitVersionType } from 'azure-devops-node-api/interfaces/GitInterfaces';
 
 // Import wikis feature modules
-import { GetWikisSchema, getWikisHandler } from './features/wikis';
+import { GetWikisSchema, getWikisHandler } from './features/wikis/get-wikis';
+import { GetWikiPageSchema, getWikiPage } from './features/wikis/get-wiki-page';
 
 // Create a safe console logging function that won't interfere with MCP protocol
 function safeLog(message: string) {
@@ -259,6 +260,11 @@ export function createAzureDevOpsServer(config: AzureDevOpsConfig): Server {
           name: 'get_wikis',
           description: 'Get details of wikis in a project',
           inputSchema: zodToJsonSchema(GetWikisSchema),
+        },
+        {
+          name: 'get_wiki_page',
+          description: 'Get the content of a wiki page',
+          inputSchema: zodToJsonSchema(GetWikiPageSchema),
         },
       ],
     };
@@ -738,6 +744,18 @@ export function createAzureDevOpsServer(config: AzureDevOpsConfig): Server {
           const result = await getWikisHandler(connection, args);
           return {
             content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'get_wiki_page': {
+          const args = GetWikiPageSchema.parse(request.params.arguments);
+          const result = await getWikiPage({
+            organizationId: args.organizationId || defaultOrg,
+            projectId: args.projectId ?? defaultProject,
+            wikiId: args.wikiId,
+            pagePath: args.pagePath,
+          });
+          return {
+            content: [{ type: 'text', text: result }],
           };
         }
 


### PR DESCRIPTION
- Add `get_wiki_page` functionality to retrieve content from a specific wiki page in Azure DevOps.
- Introduce schema validation for input parameters using `zod`.
- Update server integration to support the new tool.
- Create comprehensive documentation for the `get_wiki_page` tool.
- Implement unit and integration tests to ensure functionality and error handling.

This enhancement expands the capabilities of the Azure DevOps server for wiki management.