### PR TITLE
Fix #179: Add guidance for HTML formatting in System.History field

### DIFF
--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -56,7 +56,7 @@ export const CreateWorkItemSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Work item description in HTML format. HTML formatting required for multi-line fields like System.Description or AcceptanceCriteria. Do not use CDATA tags.',
+      'Work item description in HTML format. Multi-line text fields (i.e., System.History, AcceptanceCriteria, etc.) must use HTML format. Do not use CDATA tags.',
     ),
   assignedTo: z
     .string()
@@ -90,7 +90,7 @@ export const UpdateWorkItemSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Work item description in HTML format. HTML formatting required for multi-line fields like System.Description or AcceptanceCriteria. Do not use CDATA tags.',
+      'Work item description in HTML format. Multi-line text fields (i.e., System.History, AcceptanceCriteria, etc.) must use HTML format. Do not use CDATA tags.',
     ),
   assignedTo: z
     .string()

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -55,7 +55,9 @@ export const CreateWorkItemSchema = z.object({
   description: z
     .string()
     .optional()
-    .describe('The description of the work item'),
+    .describe(
+      'Work item description in HTML format. HTML formatting required for multi-line fields like System.Description or AcceptanceCriteria. Do not use CDATA tags.',
+    ),
   assignedTo: z
     .string()
     .optional()
@@ -73,7 +75,9 @@ export const CreateWorkItemSchema = z.object({
   additionalFields: z
     .record(z.string(), z.any())
     .optional()
-    .describe('Additional fields to set on the work item'),
+    .describe(
+      'Additional fields to set on the work item. Multi-line text fields (i.e., System.History, AcceptanceCriteria, etc.) must use HTML format. Do not use CDATA tags.',
+    ),
 });
 
 /**
@@ -85,7 +89,9 @@ export const UpdateWorkItemSchema = z.object({
   description: z
     .string()
     .optional()
-    .describe('The updated description of the work item'),
+    .describe(
+      'Work item description in HTML format. HTML formatting required for multi-line fields like System.Description or AcceptanceCriteria. Do not use CDATA tags.',
+    ),
   assignedTo: z
     .string()
     .optional()
@@ -106,7 +112,9 @@ export const UpdateWorkItemSchema = z.object({
   additionalFields: z
     .record(z.string(), z.any())
     .optional()
-    .describe('Additional fields to update on the work item, if it is System.History its best to format the comment as HTML.'),
+    .describe(
+      'Additional fields to update on the work item. Multi-line text fields (i.e., System.History, AcceptanceCriteria, etc.) must use HTML format. Do not use CDATA tags.',
+    ),
 });
 
 /**

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -106,7 +106,7 @@ export const UpdateWorkItemSchema = z.object({
   additionalFields: z
     .record(z.string(), z.any())
     .optional()
-    .describe('Additional fields to update on the work item'),
+    .describe('Additional fields to update on the work item, if it is System.History its best to format the comment as HTML.'),
 });
 
 /**


### PR DESCRIPTION
## Description
This PR addresses issue #179 by adding guidance in the schema description for adding comments to work items. It clarifies that when using the `System.History` field in `additionalFields`, comments should be formatted as HTML.

## Changes Made
- Updated the description for `additionalFields` in the `UpdateWorkItemSchema` to include guidance about HTML formatting for the System.History field
- This helps the agent understand the expected format for comments, preventing issues with plain text comments appearing incorrectly in Azure DevOps

## Testing
I've tested this change in my personal Azure DevOps environment against both story and bug work item types, confirming that:
1. The guidance is clear in the schema description
2. When the agent follows the guidance it will then format comments as HTML, it seems to do this pretty consistantly, they appear correctly in Azure DevOps

## Related Issue
Fixes #179