### PR TITLE
Fix: Use default project for code search when no projectId is specified

### DIFF
--- a/src/features/organizations/list-organizations/feature.ts
+++ b/src/features/organizations/list-organizations/feature.ts
@@ -100,7 +100,7 @@ export async function listOrganizations(
     // Handle profile API errors as authentication errors
     if (axios.isAxiosError(error) && error.config?.url?.includes('profile')) {
       throw new AzureDevOpsAuthenticationError(
-        `Authentication failed: ${error.message}`,
+        `Authentication failed: ${error.toJSON()}`,
       );
     } else if (
       error instanceof Error &&

--- a/src/features/pull-requests/update-pull-request/feature.spec.unit.ts
+++ b/src/features/pull-requests/update-pull-request/feature.spec.unit.ts
@@ -199,13 +199,18 @@ describe('updatePullRequest', () => {
   });
 
   it('should handle work item links', async () => {
+    // Define the artifactId that will be used
+    const artifactId = 'vstfs:///Git/PullRequestId/project-1/repo1/123';
+
     mockGetPullRequestById.mockResolvedValueOnce({
       repository: { id: 'repo1' },
+      artifactId: artifactId, // Add the artifactId to the mock response
     });
 
     mockUpdatePullRequest.mockResolvedValueOnce({
       pullRequestId: 123,
       repository: { id: 'repo1' },
+      artifactId: artifactId,
     });
 
     // Mocks for work items to remove
@@ -213,7 +218,7 @@ describe('updatePullRequest', () => {
       relations: [
         {
           rel: 'ArtifactLink',
-          url: 'vstfs:///Git/PullRequestId/project-1/repo1/123',
+          url: artifactId, // Use the same artifactId here
           attributes: {
             name: 'Pull Request',
           },
@@ -225,7 +230,7 @@ describe('updatePullRequest', () => {
       relations: [
         {
           rel: 'ArtifactLink',
-          url: 'vstfs:///Git/PullRequestId/project-1/repo1/123',
+          url: artifactId, // Use the same artifactId here
           attributes: {
             name: 'Pull Request',
           },


### PR DESCRIPTION
## Description
This PR fixes issue #202 where the code search feature was failing when no project ID was specified.

## Changes
1. Removed the organization-wide search option, which was not supported by the Azure DevOps API
2. Implemented a fallback to use the `AZURE_DEVOPS_DEFAULT_PROJECT` environment variable when no project ID is specified
3. Added proper error handling when no project ID is available and no default project is set
4. Updated the tests and documentation to reflect these changes

## Testing
All unit tests and integration tests are passing. The code search feature now works correctly when no project ID is specified, falling back to the default project.

Fixes #202

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of project selection in code search, ensuring the default project environment variable is used when no project is specified, and providing clear errors if neither is set.
- **Tests**
	- Added integration and unit tests to verify correct usage of the default project and error handling when project information is missing.
	- Enhanced test isolation and naming for better clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->