### PR TITLE
Support the legacy URL format.

### DIFF
--- a/src/features/users/get-me/feature.spec.unit.ts
+++ b/src/features/users/get-me/feature.spec.unit.ts
@@ -150,4 +150,36 @@ describe('getMe', () => {
       'Failed to get user information: Test API error',
     );
   });
+
+  // Test the legacy URL format of project.visualstudio.com
+  it('should work with legacy visualstudio.com URL format', async () => {
+    mockConnection = {
+      serverUrl: 'https://legacy_test_org.visualstudio.com',
+    } as WebApi;
+
+    const mockProfile = {
+      id: 'user-id-123',
+      displayName: 'Test User',
+      emailAddress: 'test.user@example.com',
+      coreRevision: 1647,
+      timeStamp: '2023-01-01T00:00:00.000Z',
+      revision: 1647,
+    };
+
+    mockAxios.get.mockResolvedValue({ data: mockProfile });
+
+    const result = await getMe(mockConnection);
+
+    // Verify that the organization name was correctly extracted from the legacy URL
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      'https://vssps.dev.azure.com/legacy_test_org/_apis/profile/profiles/me?api-version=7.1',
+      expect.any(Object),
+    );
+
+    expect(result).toEqual({
+      id: 'user-id-123',
+      displayName: 'Test User',
+      email: 'test.user@example.com',
+    });
+  });
 });

--- a/src/features/users/get-me/feature.ts
+++ b/src/features/users/get-me/feature.ts
@@ -75,8 +75,14 @@ export async function getMe(connection: WebApi): Promise<UserProfile> {
  * @returns The organization
  */
 function extractOrgFromUrl(url: string): { organization: string } {
-  // Extract organization from the URL
-  const match = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
+  // First try modern dev.azure.com format
+  let match = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
+
+  // If not found, try legacy visualstudio.com format
+  if (!match) {
+    match = url.match(/https?:\/\/([^.]+)\.visualstudio\.com/);
+  }
+
   const organization = match ? match[1] : '';
 
   if (!organization) {


### PR DESCRIPTION
Fixes #210 by adding support for URLs of the form `org_name.visualstudio.com`