### PR TITLE
 improve org name extraction from url

### DIFF
--- a/src/features/users/get-me/feature.ts
+++ b/src/features/users/get-me/feature.ts
@@ -83,6 +83,11 @@ function extractOrgFromUrl(url: string): { organization: string } {
     match = url.match(/https?:\/\/([^.]+)\.visualstudio\.com/);
   }
 
+  // Fallback: capture the first path segment for any URL
+  if (!match) {
+    match = url.match(/https?:\/\/[^/]+\/([^/]+)/);
+  }
+
   const organization = match ? match[1] : '';
 
   if (!organization) {

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -11,12 +11,16 @@ dotenv.config();
  */
 export function getOrgNameFromUrl(url?: string): string {
   if (!url) return 'unknown-organization';
-  let match = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
-  if (match) {
-    return match[1];
+  const devMatch = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
+  if (devMatch) {
+    return devMatch[1];
   }
-  match = url.match(/https?:\/\/[^/]+\/([^/]+)/);
-  return match ? match[1] : 'unknown-organization';
+  // Fallback only for Azure DevOps Server URLs
+  if (url.includes('azure')) {
+    const fallbackMatch = url.match(/https?:\/\/[^/]+\/([^/]+)/);
+    return fallbackMatch ? fallbackMatch[1] : 'unknown-organization';
+  }
+  return 'unknown-organization';
 }
 
 /**

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -11,7 +11,11 @@ dotenv.config();
  */
 export function getOrgNameFromUrl(url?: string): string {
   if (!url) return 'unknown-organization';
-  const match = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
+  let match = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
+  if (match) {
+    return match[1];
+  }
+  match = url.match(/https?:\/\/[^/]+\/([^/]+)/);
   return match ? match[1] : 'unknown-organization';
 }
 


### PR DESCRIPTION
Hi 

I’ve updated the `getOrgNameFromUrl` logic to handle both cloud and on-prem Azure DevOps URLs:

1. **Cloud URL** (`dev.azure.com`)
   ```ts
   const devMatch = url.match(/https?:\/\/dev\.azure\.com\/([^/]+)/);
   if (devMatch) return devMatch[1];
   ```
2. **On-prem/custom server** (only if URL contains "azure")
   ```ts
   const fallbackMatch = url.match(/https?:\/\/[^/]+\/([^/]+)/);
   return fallbackMatch ? fallbackMatch[1] : 'unknown-organization';
   ```
3. **Anything else** returns `"unknown-organization"` immediately.

**Behavior examples:**

| Input URL                                                 | Output                   |
| --------------------------------------------------------- | ------------------------ |
| `undefined`                                               | `unknown-organization`   |
| `https://dev.azure.com/acme-inc`                          | `acme-inc`               |
| `https://dev.azure.com/acme-inc/project`                  | `acme-inc`               |
| `https://azure.abnoosgasht.org/DefaultCollection`         | `DefaultCollection`      |
| `https://example.com/foo`                                 | `unknown-organization`   |

With this change, setting  
```
AZURE_DEVOPS_ORG_URL=https://azure.abnoosgasht.org/DefaultCollection
```  
now correctly resolves the organization ID to `DefaultCollection`. Let me know if you spot any edge cases!