### PR TITLE
Fix: Remove uuid() validator to resolve unknown format error

### DIFF
--- a/src/features/pull-requests/schemas.ts
+++ b/src/features/pull-requests/schemas.ts
@@ -62,14 +62,12 @@ export const ListPullRequestsSchema = z.object({
     .describe('Filter by pull request status'),
   creatorId: z
     .string()
-    .uuid()
     .optional()
-    .describe('Filter by creator ID (must be a UUID)'),
+    .describe('Filter by creator ID (must be a UUID string)'),
   reviewerId: z
     .string()
-    .uuid()
     .optional()
-    .describe('Filter by reviewer ID (must be a UUID)'),
+    .describe('Filter by reviewer ID (must be a UUID string)'),
   sourceRefName: z.string().optional().describe('Filter by source branch name'),
   targetRefName: z.string().optional().describe('Filter by target branch name'),
   top: z


### PR DESCRIPTION
## Description
This PR fixes issue #215 where the MCP server was throwing an error: "unknown format "uuid" ignored in schema".

## Root Cause
The error occurs because the JSON schema for the `list_pull_requests` tool includes a `format: "uuid"` attribute for the `creatorId` and `reviewerId` properties, but the MCP client/SDK's JSON schema validator doesn't recognize "uuid" as a standard format.

## Solution
The fix is to remove the `.uuid()` validator from the Zod schema for these fields, while still keeping them as string fields. This way, the JSON schema won't include the unsupported format, but the fields will still be validated as strings.

## Testing
All unit and integration tests are passing.

Fixes #215