### PR TITLE
feat(pull-requests): enhance get_pull_request_comments response with …

### DIFF
--- a/docs/tools/pull-requests.md
+++ b/docs/tools/pull-requests.md
@@ -467,8 +467,8 @@ Example response:
         "filePath": "/src/app.ts",
         "rightFileStart": { "line": 10, "offset": 5 },
         "rightFileEnd": { "line": 10, "offset": 15 },
-        "leftFileStart": null,
-        "leftFileEnd": null
+        "leftFileStart": undefined,
+        "leftFileEnd": undefined
       },
       {
         "id": 457,
@@ -484,8 +484,8 @@ Example response:
         "filePath": "/src/app.ts",
         "rightFileStart": { "line": 10, "offset": 5 },
         "rightFileEnd": { "line": 10, "offset": 15 },
-        "leftFileStart": null,
-        "leftFileEnd": null
+        "leftFileStart": undefined,
+        "leftFileEnd": undefined
       }
     ],
     "isDeleted": false
@@ -505,10 +505,10 @@ Example response:
         },
         "publishedDate": "2023-04-15T14:40:00Z",
         "filePath": null,
-        "rightFileStart": null,
-        "rightFileEnd": null,
-        "leftFileStart": null,
-        "leftFileEnd": null
+        "rightFileStart": undefined,
+        "rightFileEnd": undefined,
+        "leftFileStart": undefined,
+        "leftFileEnd": undefined
       }
     ],
     "isDeleted": false

--- a/docs/tools/pull-requests.md
+++ b/docs/tools/pull-requests.md
@@ -429,7 +429,10 @@ Each comment in the thread contains:
 - `author`: Information about the user who created the comment
 - `publishedDate`: The date and time when the comment was published
 - `filePath`: The path of the file the comment is associated with (if any)
-- `lineNumber`: The line number the comment is associated with (if any)
+- `leftFileStart`: The start position in the left file (object with `line` and `offset`), or null
+- `leftFileEnd`: The end position in the left file (object with `line` and `offset`), or null
+- `rightFileStart`: The start position in the right file (object with `line` and `offset`), or null
+- `rightFileEnd`: The end position in the right file (object with `line` and `offset`), or null
 - And various other fields and references
 
 Example response:
@@ -462,7 +465,10 @@ Example response:
         },
         "publishedDate": "2023-04-15T14:30:00Z",
         "filePath": "/src/app.ts",
-        "lineNumber": 10
+        "rightFileStart": { "line": 10, "offset": 5 },
+        "rightFileEnd": { "line": 10, "offset": 15 },
+        "leftFileStart": null,
+        "leftFileEnd": null
       },
       {
         "id": 457,
@@ -476,7 +482,10 @@ Example response:
         },
         "publishedDate": "2023-04-15T14:35:00Z",
         "filePath": "/src/app.ts",
-        "lineNumber": 10
+        "rightFileStart": { "line": 10, "offset": 5 },
+        "rightFileEnd": { "line": 10, "offset": 15 },
+        "leftFileStart": null,
+        "leftFileEnd": null
       }
     ],
     "isDeleted": false
@@ -496,7 +505,10 @@ Example response:
         },
         "publishedDate": "2023-04-15T14:40:00Z",
         "filePath": null,
-        "lineNumber": null
+        "rightFileStart": null,
+        "rightFileEnd": null,
+        "leftFileStart": null,
+        "leftFileEnd": null
       }
     ],
     "isDeleted": false
@@ -529,8 +541,8 @@ const comments = await mcpClient.callTool('get_pull_request_comments', {
 // Get comments with file path and line number information
 comments.forEach(thread => {
   thread.comments?.forEach(comment => {
-    if (comment.filePath && comment.lineNumber) {
-      console.log(`Comment on ${comment.filePath}:${comment.lineNumber}: ${comment.content}`);
+    if (comment.filePath && comment.rightFileStart && comment.rightFileEnd) {
+      console.log(`Comment on ${comment.filePath}:${comment.rightFileStart.line}-${comment.rightFileEnd.line}: ${comment.content}`);
     } else {
       console.log(`General comment: ${comment.content}`);
     }

--- a/src/features/pull-requests/get-pull-request-comments/feature.spec.int.ts
+++ b/src/features/pull-requests/get-pull-request-comments/feature.spec.int.ts
@@ -118,10 +118,13 @@ describe('getPullRequestComments integration', () => {
     expect(firstComment.id).toBeDefined();
     expect(firstComment.publishedDate).toBeDefined();
     expect(firstComment.author).toBeDefined();
-    
+
     // Verify new fields are present (may be undefined/null for general comments)
     expect(firstComment).toHaveProperty('filePath');
-    expect(firstComment).toHaveProperty('lineNumber');
+    expect(firstComment).toHaveProperty('rightFileStart');
+    expect(firstComment).toHaveProperty('rightFileEnd');
+    expect(firstComment).toHaveProperty('leftFileStart');
+    expect(firstComment).toHaveProperty('leftFileEnd');
   }, 30000);
 
   test('should get a specific comment thread by ID with file path and line number', async () => {
@@ -170,7 +173,10 @@ describe('getPullRequestComments integration', () => {
 
     // Verify new fields are present (may be undefined/null for general comments)
     expect(comment).toHaveProperty('filePath');
-    expect(comment).toHaveProperty('lineNumber');
+    expect(comment).toHaveProperty('rightFileStart');
+    expect(comment).toHaveProperty('rightFileEnd');
+    expect(comment).toHaveProperty('leftFileStart');
+    expect(comment).toHaveProperty('leftFileEnd');
   }, 30000);
 
   test('should handle pagination with top parameter', async () => {
@@ -229,7 +235,10 @@ describe('getPullRequestComments integration', () => {
     // Verify new fields are present in paginated results
     const comment = thread.comments![0];
     expect(comment).toHaveProperty('filePath');
-    expect(comment).toHaveProperty('lineNumber');
+    expect(comment).toHaveProperty('rightFileStart');
+    expect(comment).toHaveProperty('rightFileEnd');
+    expect(comment).toHaveProperty('leftFileStart');
+    expect(comment).toHaveProperty('leftFileEnd');
   }, 30000);
 
   test('should handle includeDeleted parameter', async () => {
@@ -268,7 +277,10 @@ describe('getPullRequestComments integration', () => {
       if (thread.comments && thread.comments.length > 0) {
         const comment = thread.comments[0];
         expect(comment).toHaveProperty('filePath');
-        expect(comment).toHaveProperty('lineNumber');
+        expect(comment).toHaveProperty('rightFileStart');
+        expect(comment).toHaveProperty('rightFileEnd');
+        expect(comment).toHaveProperty('leftFileStart');
+        expect(comment).toHaveProperty('leftFileEnd');
       }
     }
   }, 30000); // 30 second timeout for integration test

--- a/src/features/pull-requests/get-pull-request-comments/feature.spec.unit.ts
+++ b/src/features/pull-requests/get-pull-request-comments/feature.spec.unit.ts
@@ -81,11 +81,14 @@ describe('getPullRequestComments', () => {
     // Verify results
     expect(result).toHaveLength(1);
     expect(result[0].comments).toHaveLength(2);
-    
+
     // Verify file path and line number are added to each comment
-    result[0].comments?.forEach(comment => {
+    result[0].comments?.forEach((comment) => {
       expect(comment).toHaveProperty('filePath', '/src/app.ts');
-      expect(comment).toHaveProperty('lineNumber', 10);
+      expect(comment).toHaveProperty('rightFileStart', { line: 10, offset: 5 });
+      expect(comment).toHaveProperty('rightFileEnd', { line: 10, offset: 15 });
+      expect(comment).toHaveProperty('leftFileStart', undefined);
+      expect(comment).toHaveProperty('leftFileEnd', undefined);
     });
 
     expect(mockConnection.getGitApi).toHaveBeenCalledTimes(1);
@@ -146,11 +149,14 @@ describe('getPullRequestComments', () => {
     // Verify results
     expect(result).toHaveLength(1);
     expect(result[0].comments).toHaveLength(1);
-    
+
     // Verify file path and line number are null for comments without thread context
     const comment = result[0].comments![0];
     expect(comment).toHaveProperty('filePath', undefined);
-    expect(comment).toHaveProperty('lineNumber', null);
+    expect(comment).toHaveProperty('rightFileStart', null);
+    expect(comment).toHaveProperty('rightFileEnd', null);
+    expect(comment).toHaveProperty('leftFileStart', null);
+    expect(comment).toHaveProperty('leftFileEnd', null);
   });
 
   test('should use leftFileStart when rightFileStart is not available', async () => {
@@ -206,11 +212,14 @@ describe('getPullRequestComments', () => {
     // Verify results
     expect(result).toHaveLength(1);
     expect(result[0].comments).toHaveLength(1);
-    
-    // Verify line number is taken from leftFileStart
+
+    // Verify rightFileStart is undefined, leftFileStart is present
     const comment = result[0].comments![0];
     expect(comment).toHaveProperty('filePath', '/src/app.ts');
-    expect(comment).toHaveProperty('lineNumber', 5);
+    expect(comment).toHaveProperty('leftFileStart', { line: 5, offset: 1 });
+    expect(comment).toHaveProperty('rightFileStart', undefined);
+    expect(comment).toHaveProperty('leftFileEnd', undefined);
+    expect(comment).toHaveProperty('rightFileEnd', undefined);
   });
 
   test('should return a specific comment thread when threadId is provided', async () => {
@@ -273,11 +282,14 @@ describe('getPullRequestComments', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(threadId);
     expect(result[0].comments).toHaveLength(1);
-    
+
     // Verify file path and line number are added
     const comment = result[0].comments![0];
     expect(comment).toHaveProperty('filePath', '/src/utils.ts');
-    expect(comment).toHaveProperty('lineNumber', 15);
+    expect(comment).toHaveProperty('rightFileStart', { line: 15, offset: 1 });
+    expect(comment).toHaveProperty('leftFileStart', undefined);
+    expect(comment).toHaveProperty('leftFileEnd', undefined);
+    expect(comment).toHaveProperty('rightFileEnd', undefined);
 
     expect(mockConnection.getGitApi).toHaveBeenCalledTimes(1);
     expect(mockGitApi.getPullRequestThread).toHaveBeenCalledTimes(1);
@@ -353,16 +365,29 @@ describe('getPullRequestComments', () => {
 
     // Verify results (should only include first 2 threads)
     expect(result).toHaveLength(2);
-    expect(result).toEqual(mockCommentThreads.slice(0, 2).map(thread => ({
-      ...thread,
-      comments: thread.comments?.map(comment => ({
-        ...comment,
-        filePath: thread.threadContext?.filePath,
-        lineNumber: thread.threadContext?.rightFileStart?.line ?? null,
+    expect(result).toEqual(
+      mockCommentThreads.slice(0, 2).map((thread) => ({
+        ...thread,
+        comments: thread.comments?.map((comment) => ({
+          ...comment,
+          filePath: thread.threadContext?.filePath,
+          rightFileStart: thread.threadContext?.rightFileStart ?? null,
+          rightFileEnd: thread.threadContext?.rightFileEnd ?? null,
+          leftFileStart: thread.threadContext?.leftFileStart ?? null,
+          leftFileEnd: thread.threadContext?.leftFileEnd ?? null,
+        })),
       })),
-    })));
+    );
     expect(mockConnection.getGitApi).toHaveBeenCalledTimes(1);
     expect(mockGitApi.getThreads).toHaveBeenCalledTimes(1);
+    expect(result[0].comments![0]).toHaveProperty('rightFileStart', {
+      line: 1,
+      offset: 1,
+    });
+    expect(result[1].comments![0]).toHaveProperty('rightFileStart', {
+      line: 2,
+      offset: 1,
+    });
   });
 
   test('should handle error when API call fails', async () => {

--- a/src/features/pull-requests/get-pull-request-comments/feature.spec.unit.ts
+++ b/src/features/pull-requests/get-pull-request-comments/feature.spec.unit.ts
@@ -153,10 +153,10 @@ describe('getPullRequestComments', () => {
     // Verify file path and line number are null for comments without thread context
     const comment = result[0].comments![0];
     expect(comment).toHaveProperty('filePath', undefined);
-    expect(comment).toHaveProperty('rightFileStart', null);
-    expect(comment).toHaveProperty('rightFileEnd', null);
-    expect(comment).toHaveProperty('leftFileStart', null);
-    expect(comment).toHaveProperty('leftFileEnd', null);
+    expect(comment).toHaveProperty('rightFileStart', undefined);
+    expect(comment).toHaveProperty('rightFileEnd', undefined);
+    expect(comment).toHaveProperty('leftFileStart', undefined);
+    expect(comment).toHaveProperty('leftFileEnd', undefined);
   });
 
   test('should use leftFileStart when rightFileStart is not available', async () => {
@@ -371,10 +371,10 @@ describe('getPullRequestComments', () => {
         comments: thread.comments?.map((comment) => ({
           ...comment,
           filePath: thread.threadContext?.filePath,
-          rightFileStart: thread.threadContext?.rightFileStart ?? null,
-          rightFileEnd: thread.threadContext?.rightFileEnd ?? null,
-          leftFileStart: thread.threadContext?.leftFileStart ?? null,
-          leftFileEnd: thread.threadContext?.leftFileEnd ?? null,
+          rightFileStart: thread.threadContext?.rightFileStart ?? undefined,
+          rightFileEnd: thread.threadContext?.rightFileEnd ?? undefined,
+          leftFileStart: thread.threadContext?.leftFileStart ?? undefined,
+          leftFileEnd: thread.threadContext?.leftFileEnd ?? undefined,
         })),
       })),
     );

--- a/src/features/pull-requests/get-pull-request-comments/feature.ts
+++ b/src/features/pull-requests/get-pull-request-comments/feature.ts
@@ -73,10 +73,22 @@ function transformThread(
 
   // Get file path and positions from thread context
   const filePath = thread.threadContext?.filePath;
-  const leftFileStart = thread.threadContext?.leftFileStart ?? null;
-  const leftFileEnd = thread.threadContext?.leftFileEnd ?? null;
-  const rightFileStart = thread.threadContext?.rightFileStart ?? null;
-  const rightFileEnd = thread.threadContext?.rightFileEnd ?? null;
+  const leftFileStart =
+    thread.threadContext && 'leftFileStart' in thread.threadContext
+      ? thread.threadContext.leftFileStart
+      : undefined;
+  const leftFileEnd =
+    thread.threadContext && 'leftFileEnd' in thread.threadContext
+      ? thread.threadContext.leftFileEnd
+      : undefined;
+  const rightFileStart =
+    thread.threadContext && 'rightFileStart' in thread.threadContext
+      ? thread.threadContext.rightFileStart
+      : undefined;
+  const rightFileEnd =
+    thread.threadContext && 'rightFileEnd' in thread.threadContext
+      ? thread.threadContext.rightFileEnd
+      : undefined;
 
   // Transform each comment to include the new fields
   const transformedComments = thread.comments.map((comment) => ({

--- a/src/features/pull-requests/get-pull-request-comments/feature.ts
+++ b/src/features/pull-requests/get-pull-request-comments/feature.ts
@@ -64,22 +64,28 @@ export async function getPullRequestComments(
  * @param thread The original comment thread
  * @returns Transformed comment thread with additional fields
  */
-function transformThread(thread: GitPullRequestCommentThread): GitPullRequestCommentThread {
+function transformThread(
+  thread: GitPullRequestCommentThread,
+): GitPullRequestCommentThread {
   if (!thread.comments) {
     return thread;
   }
 
-  // Get file path and line number from thread context
+  // Get file path and positions from thread context
   const filePath = thread.threadContext?.filePath;
-  const lineNumber = thread.threadContext?.rightFileStart?.line ?? 
-                    thread.threadContext?.leftFileStart?.line ?? 
-                    null;
+  const leftFileStart = thread.threadContext?.leftFileStart ?? null;
+  const leftFileEnd = thread.threadContext?.leftFileEnd ?? null;
+  const rightFileStart = thread.threadContext?.rightFileStart ?? null;
+  const rightFileEnd = thread.threadContext?.rightFileEnd ?? null;
 
   // Transform each comment to include the new fields
-  const transformedComments = thread.comments.map(comment => ({
+  const transformedComments = thread.comments.map((comment) => ({
     ...comment,
     filePath,
-    lineNumber,
+    leftFileStart,
+    leftFileEnd,
+    rightFileStart,
+    rightFileEnd,
   }));
 
   return {


### PR DESCRIPTION
feat(pull-requests): Enhance get_pull_request_comments response with full code position info

- The get_pull_request_comments response now removes the lineNumber field and adds leftFileStart, leftFileEnd, rightFileStart, and rightFileEnd fields (type: CommentPosition, containing line and offset); filePath is retained.
- Updated unit and integration tests to assert the new fields and adapt mock data accordingly.
- Updated documentation (docs/tools/pull-requests.md) to describe the new fields and provide examples; removed all references to lineNumber.
- Keeps the structure consistent with Azure DevOps REST API, improving code review and comment location accuracy.
