### PR TITLE
feat(work-items): add work item attachment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ The Azure DevOps MCP server provides a variety of tools for interacting with Azu
 - `update_work_item`: Update an existing work item
 - `list_work_items`: List work items in a project
 - `manage_work_item_link`: Add, remove, or update links between work items
+- `create_work_item_attachment`: Upload and attach a file to a work item
+- `get_work_item_attachment`: Download an attachment from a work item
+- `delete_work_item_attachment`: Delete an attachment from a work item
 
 ### Search Tools
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -44,6 +44,9 @@ This directory contains documentation for all tools available in the Azure DevOp
 - [`get_work_item`](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/tools/work-items.md#get_work_item) - Retrieve a work item by ID
 - [`create_work_item`](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/tools/work-items.md#create_work_item) - Create a new work item
 - [`list_work_items`](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/tools/work-items.md#list_work_items) - List work items in a project
+- [`create_work_item_attachment`](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/tools/work-items.md#create_work_item_attachment) - Upload and attach a file to a work item
+- [`get_work_item_attachment`](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/tools/work-items.md#get_work_item_attachment) - Download an attachment from a work item
+- [`delete_work_item_attachment`](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/tools/work-items.md#delete_work_item_attachment) - Delete an attachment from a work item
 
 ### Pipeline Tools
 

--- a/src/features/work-items/create-work-item-attachment/feature.spec.int.ts
+++ b/src/features/work-items/create-work-item-attachment/feature.spec.int.ts
@@ -1,0 +1,195 @@
+import { WebApi } from 'azure-devops-node-api';
+import { createWorkItemAttachment } from './feature';
+import { createWorkItem } from '../create-work-item/feature';
+import {
+  getTestConnection,
+  shouldSkipIntegrationTest,
+} from '@/shared/test/test-helpers';
+import {
+  CreateWorkItemOptions,
+  CreateWorkItemAttachmentOptions,
+} from '../types';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('createWorkItemAttachment integration', () => {
+  let connection: WebApi | null = null;
+  let createdWorkItemId: number | null = null;
+  let testFilePath: string | null = null;
+
+  beforeAll(async () => {
+    // Get a real connection using environment variables
+    connection = await getTestConnection();
+
+    // Skip setup if integration tests should be skipped
+    if (shouldSkipIntegrationTest() || !connection) {
+      return;
+    }
+
+    // Create a work item to be used by the attachment tests
+    const projectName =
+      process.env.AZURE_DEVOPS_DEFAULT_PROJECT || 'DefaultProject';
+    const uniqueTitle = `Attachment Test Work Item ${new Date().toISOString()}`;
+
+    const options: CreateWorkItemOptions = {
+      title: uniqueTitle,
+      description: 'Work item for attachment integration tests',
+    };
+
+    try {
+      const workItem = await createWorkItem(
+        connection,
+        projectName,
+        'Task',
+        options,
+      );
+      if (workItem && workItem.id !== undefined) {
+        createdWorkItemId = workItem.id;
+      }
+    } catch (error) {
+      console.error('Failed to create work item for attachment tests:', error);
+    }
+
+    // Create a temporary test file
+    const tempDir = os.tmpdir();
+    testFilePath = path.join(tempDir, `test-attachment-${Date.now()}.txt`);
+    fs.writeFileSync(
+      testFilePath,
+      'This is a test file for attachment integration tests.',
+    );
+  });
+
+  afterAll(() => {
+    // Clean up the temporary test file
+    if (testFilePath && fs.existsSync(testFilePath)) {
+      fs.unlinkSync(testFilePath);
+    }
+  });
+
+  test('should add an attachment to a work item', async () => {
+    // Skip if no connection is available or if work item wasn't created
+    if (
+      shouldSkipIntegrationTest() ||
+      !connection ||
+      !createdWorkItemId ||
+      !testFilePath
+    ) {
+      return;
+    }
+
+    const options: CreateWorkItemAttachmentOptions = {
+      filePath: testFilePath,
+    };
+
+    // Act - make an actual API call to Azure DevOps
+    const result = await createWorkItemAttachment(
+      connection,
+      createdWorkItemId,
+      options,
+    );
+
+    // Assert on the actual response
+    expect(result).toBeDefined();
+    expect(result.id).toBe(createdWorkItemId);
+
+    // Verify the attachment was added
+    expect(result.relations).toBeDefined();
+    const attachmentRelation = result.relations?.find(
+      (relation) => relation.rel === 'AttachedFile',
+    );
+    expect(attachmentRelation).toBeDefined();
+  });
+
+  test('should add an attachment with a custom file name', async () => {
+    // Skip if no connection is available or if work item wasn't created
+    if (
+      shouldSkipIntegrationTest() ||
+      !connection ||
+      !createdWorkItemId ||
+      !testFilePath
+    ) {
+      return;
+    }
+
+    const customFileName = `custom-name-${Date.now()}.txt`;
+    const options: CreateWorkItemAttachmentOptions = {
+      filePath: testFilePath,
+      fileName: customFileName,
+    };
+
+    // Act - make an actual API call to Azure DevOps
+    const result = await createWorkItemAttachment(
+      connection,
+      createdWorkItemId,
+      options,
+    );
+
+    // Assert on the actual response
+    expect(result).toBeDefined();
+    expect(result.id).toBe(createdWorkItemId);
+
+    // Verify the attachment was added with the custom name
+    expect(result.relations).toBeDefined();
+    const attachmentRelation = result.relations?.find(
+      (relation) =>
+        relation.rel === 'AttachedFile' &&
+        relation.attributes?.name === customFileName,
+    );
+    expect(attachmentRelation).toBeDefined();
+  });
+
+  test('should add an attachment with a comment', async () => {
+    // Skip if no connection is available or if work item wasn't created
+    if (
+      shouldSkipIntegrationTest() ||
+      !connection ||
+      !createdWorkItemId ||
+      !testFilePath
+    ) {
+      return;
+    }
+
+    const comment = 'Test attachment comment';
+    const options: CreateWorkItemAttachmentOptions = {
+      filePath: testFilePath,
+      comment: comment,
+    };
+
+    // Act - make an actual API call to Azure DevOps
+    const result = await createWorkItemAttachment(
+      connection,
+      createdWorkItemId,
+      options,
+    );
+
+    // Assert on the actual response
+    expect(result).toBeDefined();
+    expect(result.id).toBe(createdWorkItemId);
+
+    // Verify the attachment was added with the comment
+    expect(result.relations).toBeDefined();
+    const attachmentRelation = result.relations?.find(
+      (relation) =>
+        relation.rel === 'AttachedFile' &&
+        relation.attributes?.comment === comment,
+    );
+    expect(attachmentRelation).toBeDefined();
+  });
+
+  test('should throw error when file does not exist', async () => {
+    // Skip if no connection is available or if work item wasn't created
+    if (shouldSkipIntegrationTest() || !connection || !createdWorkItemId) {
+      return;
+    }
+
+    const options: CreateWorkItemAttachmentOptions = {
+      filePath: '/path/to/nonexistent/file.txt',
+    };
+
+    // Act & Assert - should throw an error for non-existent file
+    await expect(
+      createWorkItemAttachment(connection, createdWorkItemId, options),
+    ).rejects.toThrow(/Failed to create attachment|ENOENT|does not exist/);
+  });
+});

--- a/src/features/work-items/create-work-item-attachment/feature.spec.unit.ts
+++ b/src/features/work-items/create-work-item-attachment/feature.spec.unit.ts
@@ -1,0 +1,93 @@
+import { createWorkItemAttachment } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+import * as fs from 'fs';
+
+// Mock the fs module
+jest.mock('fs');
+const mockedFs = jest.mocked(fs);
+
+// Unit tests should only focus on isolated logic
+// No real connections, HTTP requests, or dependencies
+describe('createWorkItemAttachment unit', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  // Test for required filePath validation
+  test('should throw error when filePath is not provided', async () => {
+    // Arrange - mock connection, never used due to validation error
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn(),
+    };
+
+    // Act & Assert
+    await expect(
+      createWorkItemAttachment(mockConnection, 123, {
+        filePath: '', // Empty file path
+      }),
+    ).rejects.toThrow('File path is required');
+  });
+
+  // Test for file existence validation
+  test('should throw error when file does not exist', async () => {
+    // Arrange - mock file does not exist
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn(),
+    };
+
+    // Act & Assert
+    await expect(
+      createWorkItemAttachment(mockConnection, 123, {
+        filePath: '/path/to/nonexistent/file.txt',
+      }),
+    ).rejects.toThrow('File does not exist: /path/to/nonexistent/file.txt');
+  });
+
+  // Test for error propagation
+  test('should propagate custom errors when thrown internally', async () => {
+    // Arrange - mock file exists
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(Buffer.from('test content'));
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new AzureDevOpsError('Custom error');
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      createWorkItemAttachment(mockConnection, 123, {
+        filePath: '/path/to/file.txt',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+
+    await expect(
+      createWorkItemAttachment(mockConnection, 123, {
+        filePath: '/path/to/file.txt',
+      }),
+    ).rejects.toThrow('Custom error');
+  });
+
+  test('should wrap unexpected errors in a friendly error message', async () => {
+    // Arrange - mock file exists
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(Buffer.from('test content'));
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new Error('Unexpected error');
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      createWorkItemAttachment(mockConnection, 123, {
+        filePath: '/path/to/file.txt',
+      }),
+    ).rejects.toThrow('Failed to create attachment: Unexpected error');
+  });
+});

--- a/src/features/work-items/create-work-item-attachment/feature.ts
+++ b/src/features/work-items/create-work-item-attachment/feature.ts
@@ -1,0 +1,97 @@
+import { WebApi } from 'azure-devops-node-api';
+import { WorkItemExpand } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Readable } from 'stream';
+import { AzureDevOpsError } from '../../../shared/errors';
+import { CreateWorkItemAttachmentOptions, WorkItem } from '../types';
+
+/**
+ * Create an attachment on a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param workItemId The ID of the work item to attach the file to
+ * @param options Options for creating the attachment
+ * @returns The updated work item with the attachment
+ */
+export async function createWorkItemAttachment(
+  connection: WebApi,
+  workItemId: number,
+  options: CreateWorkItemAttachmentOptions,
+): Promise<WorkItem> {
+  try {
+    // Validate required parameters
+    if (!options.filePath) {
+      throw new Error('File path is required');
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(options.filePath)) {
+      throw new Error(`File does not exist: ${options.filePath}`);
+    }
+
+    const witApi = await connection.getWorkItemTrackingApi();
+
+    // Read the file content and convert to a readable stream
+    const fileBuffer = fs.readFileSync(options.filePath);
+    const fileStream = Readable.from(fileBuffer);
+
+    // Determine the file name
+    const fileName = options.fileName || path.basename(options.filePath);
+
+    // Upload the attachment
+    // Signature: createAttachment(customHeaders, contentStream, fileName, uploadType, project, areaPath)
+    const attachmentResult = await witApi.createAttachment(
+      {},
+      fileStream as unknown as NodeJS.ReadableStream,
+      fileName,
+      undefined, // uploadType (defaults to Simple)
+      undefined, // project
+    );
+
+    if (!attachmentResult || !attachmentResult.url) {
+      throw new Error('Failed to upload attachment');
+    }
+
+    // Create the JSON patch document to add the attachment relation
+    const document = [
+      {
+        op: 'add',
+        path: '/relations/-',
+        value: {
+          rel: 'AttachedFile',
+          url: attachmentResult.url,
+          attributes: {
+            name: fileName,
+            ...(options.comment ? { comment: options.comment } : {}),
+          },
+        },
+      },
+    ];
+
+    // Update the work item to add the attachment relation
+    const updatedWorkItem = await witApi.updateWorkItem(
+      {}, // customHeaders
+      document,
+      workItemId,
+      undefined, // project
+      false, // validateOnly
+      false, // bypassRules
+      false, // suppressNotifications
+      WorkItemExpand.All, // expand
+    );
+
+    if (!updatedWorkItem) {
+      throw new Error('Failed to update work item with attachment');
+    }
+
+    return updatedWorkItem;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to create attachment: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/create-work-item-attachment/index.ts
+++ b/src/features/work-items/create-work-item-attachment/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/create-work-item-attachment/schema.ts
+++ b/src/features/work-items/create-work-item-attachment/schema.ts
@@ -1,0 +1,3 @@
+import { CreateWorkItemAttachmentSchema } from '../schemas';
+
+export { CreateWorkItemAttachmentSchema };

--- a/src/features/work-items/delete-work-item-attachment/feature.spec.int.ts
+++ b/src/features/work-items/delete-work-item-attachment/feature.spec.int.ts
@@ -1,0 +1,152 @@
+import { WebApi } from 'azure-devops-node-api';
+import { deleteWorkItemAttachment } from './feature';
+import { createWorkItemAttachment } from '../create-work-item-attachment/feature';
+import { createWorkItem } from '../create-work-item/feature';
+import { getWorkItem } from '../get-work-item/feature';
+import {
+  getTestConnection,
+  shouldSkipIntegrationTest,
+} from '@/shared/test/test-helpers';
+import {
+  CreateWorkItemOptions,
+  CreateWorkItemAttachmentOptions,
+  DeleteWorkItemAttachmentOptions,
+} from '../types';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('deleteWorkItemAttachment integration', () => {
+  let connection: WebApi | null = null;
+  let createdWorkItemId: number | null = null;
+  let uploadedAttachmentId: string | null = null;
+  let testFilePath: string | null = null;
+
+  beforeAll(async () => {
+    // Get a real connection using environment variables
+    connection = await getTestConnection();
+
+    // Skip setup if integration tests should be skipped
+    if (shouldSkipIntegrationTest() || !connection) {
+      return;
+    }
+
+    // Create a work item to be used by the attachment tests
+    const projectName =
+      process.env.AZURE_DEVOPS_DEFAULT_PROJECT || 'DefaultProject';
+    const uniqueTitle = `Delete Attachment Test Work Item ${new Date().toISOString()}`;
+
+    const createOptions: CreateWorkItemOptions = {
+      title: uniqueTitle,
+      description: 'Work item for delete attachment integration tests',
+    };
+
+    try {
+      const workItem = await createWorkItem(
+        connection,
+        projectName,
+        'Task',
+        createOptions,
+      );
+      if (workItem && workItem.id !== undefined) {
+        createdWorkItemId = workItem.id;
+      }
+    } catch (error) {
+      console.error('Failed to create work item for delete tests:', error);
+      return;
+    }
+
+    // Create a temporary test file and upload it
+    const tempDir = os.tmpdir();
+    testFilePath = path.join(tempDir, `test-delete-${Date.now()}.txt`);
+    fs.writeFileSync(
+      testFilePath,
+      'This is test content for delete integration tests.',
+    );
+
+    // Upload an attachment to the work item
+    const uploadOptions: CreateWorkItemAttachmentOptions = {
+      filePath: testFilePath,
+      fileName: 'test-delete-file.txt',
+    };
+
+    try {
+      const updatedWorkItem = await createWorkItemAttachment(
+        connection,
+        createdWorkItemId!,
+        uploadOptions,
+      );
+
+      // Find the attachment ID from the relations
+      const attachmentRelation = updatedWorkItem.relations?.find(
+        (r) => r.rel === 'AttachedFile',
+      );
+      if (attachmentRelation && attachmentRelation.url) {
+        // Extract attachment ID from URL (last segment)
+        const urlParts = attachmentRelation.url.split('/');
+        uploadedAttachmentId = urlParts[urlParts.length - 1];
+      }
+    } catch (error) {
+      console.error('Failed to upload attachment for delete tests:', error);
+    }
+  });
+
+  afterAll(() => {
+    // Clean up the temporary test file
+    if (testFilePath && fs.existsSync(testFilePath)) {
+      fs.unlinkSync(testFilePath);
+    }
+  });
+
+  test('should delete an attachment from a work item', async () => {
+    // Skip if no connection is available or prerequisites not met
+    if (
+      shouldSkipIntegrationTest() ||
+      !connection ||
+      !createdWorkItemId ||
+      !uploadedAttachmentId
+    ) {
+      return;
+    }
+
+    const options: DeleteWorkItemAttachmentOptions = {
+      workItemId: createdWorkItemId,
+      attachmentId: uploadedAttachmentId,
+    };
+
+    // Act - make an actual API call to Azure DevOps
+    const result = await deleteWorkItemAttachment(connection, options);
+
+    // Assert on the actual response
+    expect(result).toBeDefined();
+    expect(result.id).toBe(createdWorkItemId);
+
+    // Verify the attachment was removed by fetching the work item
+    const updatedWorkItem = await getWorkItem(
+      connection,
+      createdWorkItemId,
+      'relations',
+    );
+    const attachmentRelation = updatedWorkItem.relations?.find(
+      (r) => r.rel === 'AttachedFile' && r.url?.includes(uploadedAttachmentId!),
+    );
+    expect(attachmentRelation).toBeUndefined();
+  });
+
+  test('should throw error when attachment does not exist on work item', async () => {
+    // Skip if no connection is available or if work item wasn't created
+    if (shouldSkipIntegrationTest() || !connection || !createdWorkItemId) {
+      return;
+    }
+
+    const options: DeleteWorkItemAttachmentOptions = {
+      workItemId: createdWorkItemId,
+      attachmentId: '00000000-0000-0000-0000-000000000000', // Non-existent GUID
+    };
+
+    // Act & Assert - should throw an error for non-existent attachment
+    await expect(deleteWorkItemAttachment(connection, options)).rejects.toThrow(
+      /Failed to delete attachment|not found|does not exist/i,
+    );
+  });
+});

--- a/src/features/work-items/delete-work-item-attachment/feature.spec.unit.ts
+++ b/src/features/work-items/delete-work-item-attachment/feature.spec.unit.ts
@@ -1,0 +1,85 @@
+import { deleteWorkItemAttachment } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+// Unit tests should only focus on isolated logic
+// No real connections, HTTP requests, or dependencies
+describe('deleteWorkItemAttachment unit', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  // Test for required workItemId validation
+  test('should throw error when workItemId is not provided', async () => {
+    // Arrange - mock connection, never used due to validation error
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn(),
+    };
+
+    // Act & Assert
+    await expect(
+      deleteWorkItemAttachment(mockConnection, {
+        workItemId: 0, // Invalid work item ID
+        attachmentId: 'abc-123',
+      }),
+    ).rejects.toThrow('Work item ID is required');
+  });
+
+  // Test for required attachmentId validation
+  test('should throw error when attachmentId is not provided', async () => {
+    // Arrange - mock connection, never used due to validation error
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn(),
+    };
+
+    // Act & Assert
+    await expect(
+      deleteWorkItemAttachment(mockConnection, {
+        workItemId: 123,
+        attachmentId: '', // Empty attachment ID
+      }),
+    ).rejects.toThrow('Attachment ID is required');
+  });
+
+  // Test for error propagation
+  test('should propagate custom errors when thrown internally', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new AzureDevOpsError('Custom error');
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      deleteWorkItemAttachment(mockConnection, {
+        workItemId: 123,
+        attachmentId: 'abc-123',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+
+    await expect(
+      deleteWorkItemAttachment(mockConnection, {
+        workItemId: 123,
+        attachmentId: 'abc-123',
+      }),
+    ).rejects.toThrow('Custom error');
+  });
+
+  test('should wrap unexpected errors in a friendly error message', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new Error('Unexpected error');
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      deleteWorkItemAttachment(mockConnection, {
+        workItemId: 123,
+        attachmentId: 'abc-123',
+      }),
+    ).rejects.toThrow('Failed to delete attachment: Unexpected error');
+  });
+});

--- a/src/features/work-items/delete-work-item-attachment/feature.ts
+++ b/src/features/work-items/delete-work-item-attachment/feature.ts
@@ -1,0 +1,88 @@
+import { WebApi } from 'azure-devops-node-api';
+import { WorkItemExpand } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+import { DeleteWorkItemAttachmentOptions, WorkItem } from '../types';
+
+/**
+ * Delete an attachment from a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for deleting the attachment
+ * @returns The updated work item without the attachment
+ */
+export async function deleteWorkItemAttachment(
+  connection: WebApi,
+  options: DeleteWorkItemAttachmentOptions,
+): Promise<WorkItem> {
+  try {
+    // Validate required parameters
+    if (!options.workItemId) {
+      throw new Error('Work item ID is required');
+    }
+
+    if (!options.attachmentId) {
+      throw new Error('Attachment ID is required');
+    }
+
+    const witApi = await connection.getWorkItemTrackingApi();
+
+    // Get the work item with relations to find the attachment
+    const workItem = await witApi.getWorkItem(
+      options.workItemId,
+      undefined,
+      undefined,
+      WorkItemExpand.Relations,
+    );
+
+    if (!workItem) {
+      throw new Error(`Work item ${options.workItemId} not found`);
+    }
+
+    // Find the attachment relation by matching the attachment ID in the URL
+    const relations = workItem.relations || [];
+    const attachmentIndex = relations.findIndex(
+      (relation) =>
+        relation.rel === 'AttachedFile' &&
+        relation.url?.includes(options.attachmentId),
+    );
+
+    if (attachmentIndex === -1) {
+      throw new Error(
+        `Attachment ${options.attachmentId} not found on work item ${options.workItemId}`,
+      );
+    }
+
+    // Create the JSON patch document to remove the attachment relation
+    const document = [
+      {
+        op: 'remove',
+        path: `/relations/${attachmentIndex}`,
+      },
+    ];
+
+    // Update the work item to remove the attachment relation
+    const updatedWorkItem = await witApi.updateWorkItem(
+      {}, // customHeaders
+      document,
+      options.workItemId,
+      undefined, // project
+      false, // validateOnly
+      false, // bypassRules
+      false, // suppressNotifications
+      WorkItemExpand.All, // expand
+    );
+
+    if (!updatedWorkItem) {
+      throw new Error('Failed to update work item after removing attachment');
+    }
+
+    return updatedWorkItem;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to delete attachment: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/delete-work-item-attachment/index.ts
+++ b/src/features/work-items/delete-work-item-attachment/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/delete-work-item-attachment/schema.ts
+++ b/src/features/work-items/delete-work-item-attachment/schema.ts
@@ -1,0 +1,3 @@
+import { DeleteWorkItemAttachmentSchema } from '../schemas';
+
+export { DeleteWorkItemAttachmentSchema };

--- a/src/features/work-items/get-work-item-attachment/feature.spec.int.ts
+++ b/src/features/work-items/get-work-item-attachment/feature.spec.int.ts
@@ -1,0 +1,166 @@
+import { WebApi } from 'azure-devops-node-api';
+import { getWorkItemAttachment } from './feature';
+import { createWorkItemAttachment } from '../create-work-item-attachment/feature';
+import { createWorkItem } from '../create-work-item/feature';
+import {
+  getTestConnection,
+  shouldSkipIntegrationTest,
+} from '@/shared/test/test-helpers';
+import {
+  CreateWorkItemOptions,
+  CreateWorkItemAttachmentOptions,
+  GetWorkItemAttachmentOptions,
+} from '../types';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('getWorkItemAttachment integration', () => {
+  let connection: WebApi | null = null;
+  let createdWorkItemId: number | null = null;
+  let uploadedAttachmentId: string | null = null;
+  let testFilePath: string | null = null;
+  let downloadPath: string | null = null;
+  const testFileContent =
+    'This is test content for download integration tests.';
+
+  beforeAll(async () => {
+    // Get a real connection using environment variables
+    connection = await getTestConnection();
+
+    // Skip setup if integration tests should be skipped
+    if (shouldSkipIntegrationTest() || !connection) {
+      return;
+    }
+
+    // Create a work item to be used by the attachment tests
+    const projectName =
+      process.env.AZURE_DEVOPS_DEFAULT_PROJECT || 'DefaultProject';
+    const uniqueTitle = `Download Attachment Test Work Item ${new Date().toISOString()}`;
+
+    const createOptions: CreateWorkItemOptions = {
+      title: uniqueTitle,
+      description: 'Work item for download attachment integration tests',
+    };
+
+    try {
+      const workItem = await createWorkItem(
+        connection,
+        projectName,
+        'Task',
+        createOptions,
+      );
+      if (workItem && workItem.id !== undefined) {
+        createdWorkItemId = workItem.id;
+      }
+    } catch (error) {
+      console.error('Failed to create work item for download tests:', error);
+      return;
+    }
+
+    // Create a temporary test file and upload it
+    const tempDir = os.tmpdir();
+    testFilePath = path.join(tempDir, `test-download-${Date.now()}.txt`);
+    fs.writeFileSync(testFilePath, testFileContent);
+
+    // Upload an attachment to the work item
+    const uploadOptions: CreateWorkItemAttachmentOptions = {
+      filePath: testFilePath,
+      fileName: 'test-download-file.txt',
+    };
+
+    try {
+      const updatedWorkItem = await createWorkItemAttachment(
+        connection,
+        createdWorkItemId!,
+        uploadOptions,
+      );
+
+      // Find the attachment ID from the relations
+      const attachmentRelation = updatedWorkItem.relations?.find(
+        (r) => r.rel === 'AttachedFile',
+      );
+      if (attachmentRelation && attachmentRelation.url) {
+        // Extract attachment ID from URL (last segment)
+        const urlParts = attachmentRelation.url.split('/');
+        uploadedAttachmentId = urlParts[urlParts.length - 1];
+      }
+    } catch (error) {
+      console.error('Failed to upload attachment for download tests:', error);
+    }
+
+    // Set up download path
+    downloadPath = path.join(tempDir, `downloaded-${Date.now()}.txt`);
+  });
+
+  afterAll(() => {
+    // Clean up the temporary test files
+    if (testFilePath && fs.existsSync(testFilePath)) {
+      fs.unlinkSync(testFilePath);
+    }
+    if (downloadPath && fs.existsSync(downloadPath)) {
+      fs.unlinkSync(downloadPath);
+    }
+  });
+
+  test('should download an attachment from Azure DevOps', async () => {
+    // Skip if no connection is available or prerequisites not met
+    if (
+      shouldSkipIntegrationTest() ||
+      !connection ||
+      !createdWorkItemId ||
+      !uploadedAttachmentId ||
+      !downloadPath
+    ) {
+      return;
+    }
+
+    const options: GetWorkItemAttachmentOptions = {
+      attachmentId: uploadedAttachmentId,
+      outputPath: downloadPath,
+    };
+
+    // Act - make an actual API call to Azure DevOps
+    const result = await getWorkItemAttachment(connection, options);
+
+    // Assert on the actual response
+    expect(result).toBeDefined();
+    expect(result.filePath).toBe(downloadPath);
+    expect(result.size).toBeGreaterThan(0);
+
+    // Verify the file was downloaded
+    expect(fs.existsSync(downloadPath)).toBe(true);
+
+    // Verify the content matches
+    const downloadedContent = fs.readFileSync(downloadPath, 'utf-8');
+    expect(downloadedContent).toBe(testFileContent);
+  });
+
+  test('should throw error when attachment does not exist', async () => {
+    // Skip if no connection is available
+    if (shouldSkipIntegrationTest() || !connection) {
+      return;
+    }
+
+    const tempDir = os.tmpdir();
+    const nonExistentDownloadPath = path.join(
+      tempDir,
+      `nonexistent-${Date.now()}.txt`,
+    );
+
+    const options: GetWorkItemAttachmentOptions = {
+      attachmentId: '00000000-0000-0000-0000-000000000000', // Non-existent GUID
+      outputPath: nonExistentDownloadPath,
+    };
+
+    // Act & Assert - should throw an error for non-existent attachment
+    await expect(getWorkItemAttachment(connection, options)).rejects.toThrow(
+      /Failed to get attachment|not found|404/i,
+    );
+
+    // Clean up if file was somehow created
+    if (fs.existsSync(nonExistentDownloadPath)) {
+      fs.unlinkSync(nonExistentDownloadPath);
+    }
+  });
+});

--- a/src/features/work-items/get-work-item-attachment/feature.spec.unit.ts
+++ b/src/features/work-items/get-work-item-attachment/feature.spec.unit.ts
@@ -1,0 +1,85 @@
+import { getWorkItemAttachment } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+// Unit tests should only focus on isolated logic
+// No real connections, HTTP requests, or dependencies
+describe('getWorkItemAttachment unit', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  // Test for required attachmentId validation
+  test('should throw error when attachmentId is not provided', async () => {
+    // Arrange - mock connection, never used due to validation error
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn(),
+    };
+
+    // Act & Assert
+    await expect(
+      getWorkItemAttachment(mockConnection, {
+        attachmentId: '', // Empty attachment ID
+        outputPath: '/path/to/output.txt',
+      }),
+    ).rejects.toThrow('Attachment ID is required');
+  });
+
+  // Test for required outputPath validation
+  test('should throw error when outputPath is not provided', async () => {
+    // Arrange - mock connection, never used due to validation error
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn(),
+    };
+
+    // Act & Assert
+    await expect(
+      getWorkItemAttachment(mockConnection, {
+        attachmentId: 'abc-123',
+        outputPath: '', // Empty output path
+      }),
+    ).rejects.toThrow('Output path is required');
+  });
+
+  // Test for error propagation
+  test('should propagate custom errors when thrown internally', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new AzureDevOpsError('Custom error');
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      getWorkItemAttachment(mockConnection, {
+        attachmentId: 'abc-123',
+        outputPath: '/path/to/output.txt',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+
+    await expect(
+      getWorkItemAttachment(mockConnection, {
+        attachmentId: 'abc-123',
+        outputPath: '/path/to/output.txt',
+      }),
+    ).rejects.toThrow('Custom error');
+  });
+
+  test('should wrap unexpected errors in a friendly error message', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new Error('Unexpected error');
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      getWorkItemAttachment(mockConnection, {
+        attachmentId: 'abc-123',
+        outputPath: '/path/to/output.txt',
+      }),
+    ).rejects.toThrow('Failed to get attachment: Unexpected error');
+  });
+});

--- a/src/features/work-items/get-work-item-attachment/feature.ts
+++ b/src/features/work-items/get-work-item-attachment/feature.ts
@@ -1,0 +1,74 @@
+import { WebApi } from 'azure-devops-node-api';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AzureDevOpsError } from '../../../shared/errors';
+import {
+  GetWorkItemAttachmentOptions,
+  GetWorkItemAttachmentResult,
+} from '../types';
+
+/**
+ * Get an attachment from a work item and save it to the local filesystem
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for getting the attachment
+ * @returns The result of the operation including file path and size
+ */
+export async function getWorkItemAttachment(
+  connection: WebApi,
+  options: GetWorkItemAttachmentOptions,
+): Promise<GetWorkItemAttachmentResult> {
+  try {
+    // Validate required parameters
+    if (!options.attachmentId) {
+      throw new Error('Attachment ID is required');
+    }
+
+    if (!options.outputPath) {
+      throw new Error('Output path is required');
+    }
+
+    const witApi = await connection.getWorkItemTrackingApi();
+
+    // Download the attachment content
+    const attachmentStream = await witApi.getAttachmentContent(
+      options.attachmentId,
+    );
+
+    if (!attachmentStream) {
+      throw new Error('Failed to download attachment: No content received');
+    }
+
+    // Ensure the output directory exists
+    const outputDir = path.dirname(options.outputPath);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Write the attachment to the output file
+    const writeStream = fs.createWriteStream(options.outputPath);
+
+    await new Promise<void>((resolve, reject) => {
+      attachmentStream.pipe(writeStream);
+      attachmentStream.on('error', reject);
+      writeStream.on('error', reject);
+      writeStream.on('finish', resolve);
+    });
+
+    // Get the file size
+    const stats = fs.statSync(options.outputPath);
+
+    return {
+      filePath: options.outputPath,
+      fileName: path.basename(options.outputPath),
+      size: stats.size,
+    };
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to get attachment: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/get-work-item-attachment/index.ts
+++ b/src/features/work-items/get-work-item-attachment/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/get-work-item-attachment/schema.ts
+++ b/src/features/work-items/get-work-item-attachment/schema.ts
@@ -1,0 +1,3 @@
+import { GetWorkItemAttachmentSchema } from '../schemas';
+
+export { GetWorkItemAttachmentSchema };

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -8,6 +8,9 @@ export * from './get-work-item';
 export * from './create-work-item';
 export * from './update-work-item';
 export * from './manage-work-item-link';
+export * from './create-work-item-attachment';
+export * from './get-work-item-attachment';
+export * from './delete-work-item-attachment';
 
 // Export tool definitions
 export * from './tool-definitions';
@@ -26,11 +29,17 @@ import {
   CreateWorkItemSchema,
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
+  CreateWorkItemAttachmentSchema,
+  GetWorkItemAttachmentSchema,
+  DeleteWorkItemAttachmentSchema,
   listWorkItems,
   getWorkItem,
   createWorkItem,
   updateWorkItem,
   manageWorkItemLink,
+  createWorkItemAttachment,
+  getWorkItemAttachment,
+  deleteWorkItemAttachment,
 } from './';
 
 // Define the response type based on observed usage
@@ -51,6 +60,9 @@ export const isWorkItemsRequest: RequestIdentifier = (
     'create_work_item',
     'update_work_item',
     'manage_work_item_link',
+    'create_work_item_attachment',
+    'get_work_item_attachment',
+    'delete_work_item_attachment',
   ].includes(toolName);
 };
 
@@ -138,6 +150,45 @@ export const handleWorkItemsRequest: RequestHandler = async (
           comment: args.comment,
         },
       );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'create_work_item_attachment': {
+      const args = CreateWorkItemAttachmentSchema.parse(
+        request.params.arguments,
+      );
+      const result = await createWorkItemAttachment(
+        connection,
+        args.workItemId,
+        {
+          filePath: args.filePath,
+          fileName: args.fileName,
+          comment: args.comment,
+        },
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_work_item_attachment': {
+      const args = GetWorkItemAttachmentSchema.parse(request.params.arguments);
+      const result = await getWorkItemAttachment(connection, {
+        attachmentId: args.attachmentId,
+        outputPath: args.outputPath,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'delete_work_item_attachment': {
+      const args = DeleteWorkItemAttachmentSchema.parse(
+        request.params.arguments,
+      );
+      const result = await deleteWorkItemAttachment(connection, {
+        workItemId: args.workItemId,
+        attachmentId: args.attachmentId,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -147,3 +147,53 @@ export const ManageWorkItemLinkSchema = z.object({
     .optional()
     .describe('Optional comment explaining the link'),
 });
+
+/**
+ * Schema for creating an attachment on a work item
+ */
+export const CreateWorkItemAttachmentSchema = z.object({
+  workItemId: z
+    .number()
+    .describe('The ID of the work item to attach the file to'),
+  filePath: z
+    .string()
+    .describe('The absolute path to the file to upload as an attachment'),
+  fileName: z
+    .string()
+    .optional()
+    .describe(
+      'The name to use for the attachment. If not provided, the name will be extracted from the file path.',
+    ),
+  comment: z
+    .string()
+    .optional()
+    .describe('Optional comment for the attachment'),
+});
+
+/**
+ * Schema for getting an attachment from a work item
+ */
+export const GetWorkItemAttachmentSchema = z.object({
+  attachmentId: z
+    .string()
+    .describe(
+      'The ID (GUID) of the attachment to download. Can be obtained from the work item relations.',
+    ),
+  outputPath: z
+    .string()
+    .describe('The absolute path where the attachment will be saved'),
+});
+
+/**
+ * Schema for deleting an attachment from a work item
+ */
+export const DeleteWorkItemAttachmentSchema = z.object({
+  workItemId: z
+    .number()
+    .describe('The ID of the work item to delete the attachment from'),
+  attachmentId: z
+    .string()
+    .describe(
+      'The ID (GUID) of the attachment to delete. Can be obtained from the work item relations.',
+    ),
+});

--- a/src/features/work-items/tool-definitions.ts
+++ b/src/features/work-items/tool-definitions.ts
@@ -6,6 +6,9 @@ import {
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   GetWorkItemSchema,
+  CreateWorkItemAttachmentSchema,
+  GetWorkItemAttachmentSchema,
+  DeleteWorkItemAttachmentSchema,
 } from './schemas';
 
 /**
@@ -36,5 +39,23 @@ export const workItemsTools: ToolDefinition[] = [
     name: 'manage_work_item_link',
     description: 'Add or remove links between work items',
     inputSchema: zodToJsonSchema(ManageWorkItemLinkSchema),
+  },
+  {
+    name: 'create_work_item_attachment',
+    description:
+      'Upload a file and attach it to a work item. The file is read from the local filesystem, uploaded to Azure DevOps, and linked to the specified work item.',
+    inputSchema: zodToJsonSchema(CreateWorkItemAttachmentSchema),
+  },
+  {
+    name: 'get_work_item_attachment',
+    description:
+      'Download an attachment from Azure DevOps and save it to the local filesystem. The attachment ID can be obtained from the work item relations.',
+    inputSchema: zodToJsonSchema(GetWorkItemAttachmentSchema),
+  },
+  {
+    name: 'delete_work_item_attachment',
+    description:
+      'Delete an attachment from a work item. The attachment ID can be obtained from the work item relations.',
+    inputSchema: zodToJsonSchema(DeleteWorkItemAttachmentSchema),
   },
 ];

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -43,5 +43,39 @@ export interface UpdateWorkItemOptions {
   additionalFields?: Record<string, string | number | boolean | null>;
 }
 
+/**
+ * Options for creating an attachment on a work item
+ */
+export interface CreateWorkItemAttachmentOptions {
+  filePath: string;
+  fileName?: string;
+  comment?: string;
+}
+
+/**
+ * Options for getting an attachment from a work item
+ */
+export interface GetWorkItemAttachmentOptions {
+  attachmentId: string;
+  outputPath: string;
+}
+
+/**
+ * Result of getting an attachment
+ */
+export interface GetWorkItemAttachmentResult {
+  filePath: string;
+  fileName: string;
+  size: number;
+}
+
+/**
+ * Options for deleting an attachment from a work item
+ */
+export interface DeleteWorkItemAttachmentOptions {
+  workItemId: number;
+  attachmentId: string;
+}
+
 // Re-export WorkItem and WorkItemReference types for convenience
 export type { WorkItem, WorkItemReference };


### PR DESCRIPTION
Add three new tools for managing work item attachments:
- create_work_item_attachment: Upload and attach files to work items
- get_work_item_attachment: Download attachments to local filesystem
- delete_work_item_attachment: Remove attachments from work items

Includes full test coverage (unit and integration tests) and documentation.