### PR TITLE
feat(work-items): add get_workitem_description and execute_wiql tools

### DIFF
--- a/src/features/work-items/execute-wiql/feature.ts
+++ b/src/features/work-items/execute-wiql/feature.ts
@@ -1,0 +1,152 @@
+import { WebApi } from 'azure-devops-node-api';
+import { TeamContext } from 'azure-devops-node-api/interfaces/CoreInterfaces';
+import { WorkItemExpand } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import {
+  AzureDevOpsError,
+  AzureDevOpsAuthenticationError,
+  AzureDevOpsResourceNotFoundError,
+} from '../../../shared/errors';
+import { ExecuteWiqlOptions, WiqlQueryResult } from './schema';
+
+/**
+ * Map expand parameter to Azure DevOps API enum
+ */
+function mapExpandParameter(
+  expand?: 'none' | 'relations' | 'fields' | 'links' | 'all',
+): WorkItemExpand {
+  const expandMap: Record<string, WorkItemExpand> = {
+    none: WorkItemExpand.None,
+    relations: WorkItemExpand.Relations,
+    fields: WorkItemExpand.Fields,
+    links: WorkItemExpand.Links,
+    all: WorkItemExpand.All,
+  };
+  return expandMap[expand || 'fields'] || WorkItemExpand.Fields;
+}
+
+/**
+ * Execute a WIQL query
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for executing the WIQL query
+ * @returns Query result with work items and metadata
+ */
+export async function executeWiql(
+  connection: WebApi,
+  options: ExecuteWiqlOptions,
+): Promise<WiqlQueryResult> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+    const {
+      query,
+      projectId,
+      teamId,
+      top = 200,
+      timePrecision = false,
+      expand = 'fields',
+    } = options;
+
+    // Create team context if project or team specified
+    const teamContext: TeamContext | undefined =
+      projectId || teamId
+        ? {
+            project: projectId,
+            team: teamId,
+          }
+        : undefined;
+
+    // Execute WIQL query
+    const queryResult = await witApi.queryByWiql(
+      { query },
+      teamContext,
+      timePrecision,
+    );
+
+    if (!queryResult) {
+      return {
+        workItems: [],
+        queryType: undefined,
+        columns: [],
+      };
+    }
+
+    // Extract work item references
+    const workItemRefs = queryResult.workItems || [];
+
+    // Apply top limit
+    const limitedRefs = workItemRefs.slice(0, top);
+
+    // Extract work item IDs
+    const workItemIds = limitedRefs
+      .map((ref) => ref.id)
+      .filter((id): id is number => id !== undefined);
+
+    if (workItemIds.length === 0) {
+      return {
+        workItems: [],
+        queryType: queryResult.queryType,
+        columns: queryResult.columns || [],
+        asOf: queryResult.asOf,
+        sortColumns: queryResult.sortColumns || [],
+      };
+    }
+
+    // Determine which fields to fetch based on expand parameter
+    let fields: string[] | undefined;
+    if (expand === 'none') {
+      fields = ['System.Id'];
+    } else if (expand === 'fields') {
+      // Fetch fields specified in query columns
+      if (queryResult.columns && queryResult.columns.length > 0) {
+        fields = queryResult.columns.map((col) => col.referenceName || '');
+      }
+    }
+    // For 'relations', 'links', 'all' - fetch all fields (fields = undefined)
+
+    // Fetch full work item details
+    const expandEnum = mapExpandParameter(expand);
+    const workItems = await witApi.getWorkItems(
+      workItemIds,
+      fields,
+      queryResult.asOf,
+      expandEnum,
+    );
+
+    return {
+      workItems: workItems || [],
+      queryType: queryResult.queryType,
+      columns: queryResult.columns || [],
+      asOf: queryResult.asOf,
+      sortColumns: queryResult.sortColumns || [],
+    };
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+
+    // Check for specific error types and convert to appropriate Azure DevOps errors
+    if (error instanceof Error) {
+      if (
+        error.message.includes('Authentication') ||
+        error.message.includes('Unauthorized')
+      ) {
+        throw new AzureDevOpsAuthenticationError(
+          `Failed to authenticate: ${error.message}`,
+        );
+      }
+
+      if (
+        error.message.includes('not found') ||
+        error.message.includes('does not exist')
+      ) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Resource not found: ${error.message}`,
+        );
+      }
+    }
+
+    throw new AzureDevOpsError(
+      `Failed to execute WIQL query: ${error instanceof Error ? error.message : String(error)}\n\nQuery: ${options.query}`,
+    );
+  }
+}

--- a/src/features/work-items/execute-wiql/index.ts
+++ b/src/features/work-items/execute-wiql/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/execute-wiql/schema.ts
+++ b/src/features/work-items/execute-wiql/schema.ts
@@ -1,0 +1,43 @@
+/**
+ * Schema and types for execute-wiql feature
+ */
+import {
+  WorkItem,
+  QueryType,
+  WorkItemFieldReference,
+  WorkItemQuerySortColumn,
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+
+/**
+ * Options for executing a WIQL query
+ */
+export interface ExecuteWiqlOptions {
+  /** The WIQL query to execute */
+  query: string;
+  /** The project ID or name (optional) */
+  projectId?: string;
+  /** The team ID (optional) */
+  teamId?: string;
+  /** Maximum number of work items to return */
+  top?: number;
+  /** Whether to include time precision in date fields */
+  timePrecision?: boolean;
+  /** Level of detail to include in the response */
+  expand?: 'none' | 'relations' | 'fields' | 'links' | 'all';
+}
+
+/**
+ * Result of executing a WIQL query
+ */
+export interface WiqlQueryResult {
+  /** The work items returned by the query */
+  workItems: WorkItem[];
+  /** The type of query (flat, tree, oneHop) */
+  queryType?: QueryType;
+  /** The columns defined in the query */
+  columns?: WorkItemFieldReference[];
+  /** The date/time when the query was executed */
+  asOf?: Date;
+  /** Sort columns for the query */
+  sortColumns?: WorkItemQuerySortColumn[];
+}

--- a/src/features/work-items/get-work-item-description/feature.ts
+++ b/src/features/work-items/get-work-item-description/feature.ts
@@ -1,0 +1,63 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  AzureDevOpsError,
+  AzureDevOpsAuthenticationError,
+  AzureDevOpsResourceNotFoundError,
+} from '../../../shared/errors';
+
+/**
+ * Get the description of a specific work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param workItemId The ID of the work item
+ * @returns The description of the work item in HTML format
+ */
+export async function getWorkItemDescription(
+  connection: WebApi,
+  workItemId: number,
+): Promise<string> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+    const workItem = await witApi.getWorkItem(workItemId, [
+      'System.Description',
+    ]);
+
+    if (!workItem) {
+      throw new AzureDevOpsResourceNotFoundError(
+        `Work item ${workItemId} not found`,
+      );
+    }
+
+    const description = workItem.fields?.['System.Description'] ?? '';
+    return description;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+
+    // Check for specific error types and convert to appropriate Azure DevOps errors
+    if (error instanceof Error) {
+      if (
+        error.message.includes('Authentication') ||
+        error.message.includes('Unauthorized')
+      ) {
+        throw new AzureDevOpsAuthenticationError(
+          `Failed to authenticate: ${error.message}`,
+        );
+      }
+
+      if (
+        error.message.includes('not found') ||
+        error.message.includes('does not exist')
+      ) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Work item ${workItemId} not found: ${error.message}`,
+        );
+      }
+    }
+
+    throw new AzureDevOpsError(
+      `Failed to get work item description: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/get-work-item-description/index.ts
+++ b/src/features/work-items/get-work-item-description/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/get-work-item-description/schema.ts
+++ b/src/features/work-items/get-work-item-description/schema.ts
@@ -1,0 +1,11 @@
+/**
+ * Schema and types for get-work-item-description feature
+ */
+
+/**
+ * Options for getting a work item description
+ */
+export interface GetWorkItemDescriptionOptions {
+  /** The ID of the work item */
+  workItemId: number;
+}

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -15,6 +15,13 @@ export const GetWorkItemSchema = z.object({
 });
 
 /**
+ * Schema for getting a work item description
+ */
+export const GetWorkItemDescriptionSchema = z.object({
+  workItemId: z.number().describe('The ID of the work item'),
+});
+
+/**
  * Schema for listing work items
  */
 export const ListWorkItemsSchema = z.object({
@@ -146,4 +153,45 @@ export const ManageWorkItemLinkSchema = z.object({
     .string()
     .optional()
     .describe('Optional comment explaining the link'),
+});
+
+/**
+ * Schema for executing a WIQL query
+ */
+export const ExecuteWiqlSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "Work Item Query Language (WIQL) query to execute. Example: SELECT [System.Id], [System.Title] FROM WorkItems WHERE [System.State] = 'Active'",
+    ),
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      `The ID or name of the project to execute query against (Default: ${defaultProject})`,
+    ),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  teamId: z
+    .string()
+    .optional()
+    .describe('The ID of the team to execute query against'),
+  top: z
+    .number()
+    .optional()
+    .describe('Maximum number of work items to return (default: 200)'),
+  timePrecision: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to include time precision in date fields (default: false)',
+    ),
+  expand: z
+    .enum(['none', 'relations', 'fields', 'links', 'all'])
+    .optional()
+    .describe(
+      'Level of detail to include for returned work items (default: fields)',
+    ),
 });

--- a/src/features/work-items/tool-definitions.ts
+++ b/src/features/work-items/tool-definitions.ts
@@ -6,6 +6,8 @@ import {
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   GetWorkItemSchema,
+  GetWorkItemDescriptionSchema,
+  ExecuteWiqlSchema,
 } from './schemas';
 
 /**
@@ -23,6 +25,11 @@ export const workItemsTools: ToolDefinition[] = [
     inputSchema: zodToJsonSchema(GetWorkItemSchema),
   },
   {
+    name: 'get_workitem_description',
+    description: 'Get the description of a specific work item',
+    inputSchema: zodToJsonSchema(GetWorkItemDescriptionSchema),
+  },
+  {
     name: 'create_work_item',
     description: 'Create a new work item',
     inputSchema: zodToJsonSchema(CreateWorkItemSchema),
@@ -36,5 +43,11 @@ export const workItemsTools: ToolDefinition[] = [
     name: 'manage_work_item_link',
     description: 'Add or remove links between work items',
     inputSchema: zodToJsonSchema(ManageWorkItemLinkSchema),
+  },
+  {
+    name: 'execute_wiql',
+    description:
+      'Execute a Work Item Query Language (WIQL) query to search and filter work items in Azure DevOps. Returns detailed work item information based on the query with full metadata including columns, query type, and execution time.',
+    inputSchema: zodToJsonSchema(ExecuteWiqlSchema),
   },
 ];


### PR DESCRIPTION
## Summary

This PR adds two new tools to enhance work item functionality:

### 1. `get_workitem_description`
Retrieves only the `System.Description` field from a work item, returning HTML content. This is useful for focused description access without fetching all work item fields.

**Use case:** When you only need the description content for analysis, documentation, or display purposes.

### 2. `execute_wiql` ⭐
Executes WIQL (Work Item Query Language) queries with support for advanced filtering, sorting, and field expansion. This enables complex work item searches beyond basic list operations.

**Features:**
- Full WIQL query support with project/team context
- Configurable result limits and field expansion options
- Time precision control for date fields
- Returns work items with query metadata (columns, type, sort order, execution time)

**Use case:** Advanced work item queries that require complex filtering, joins, or custom field selection.

## Why these tools?

Both tools fill gaps in the current API:
- `get_workitem_description` provides lightweight access to work item descriptions
- `execute_wiql` enables power users to leverage Azure DevOps' native query language for complex searches

## Technical Details

- Follows existing patterns for error handling and authentication
- Maintains backward compatibility
- Includes comprehensive TypeScript types and schemas
- All code passes linting and type checking

## Related Issues

This PR complements the ongoing work on work item enhancements but focuses on two unique capabilities not covered by existing PRs.

## Test Plan

- [x] TypeScript compilation passes
- [x] ESLint validation passes
- [x] Follows existing code patterns
- [x] Maintains backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/claude-code)