### PR TITLE
feat(work-items): add get and add comment tools

### DIFF
--- a/src/features/work-items/add-work-item-comment/feature.ts
+++ b/src/features/work-items/add-work-item-comment/feature.ts
@@ -1,0 +1,42 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  Comment,
+  CommentCreate,
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+/**
+ * Add a comment to a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param project The ID or name of the project
+ * @param workItemId The ID of the work item
+ * @param text The comment text (markdown supported)
+ * @returns The created comment
+ */
+export async function addWorkItemComment(
+  connection: WebApi,
+  project: string,
+  workItemId: number,
+  text: string,
+): Promise<Comment> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+
+    const request: CommentCreate = { text };
+    const comment = await witApi.addComment(request, project, workItemId);
+
+    if (!comment) {
+      throw new Error('Failed to create work item comment');
+    }
+
+    return comment;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to add work item comment: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/add-work-item-comment/index.ts
+++ b/src/features/work-items/add-work-item-comment/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/work-items/get-work-item-comments/feature.ts
+++ b/src/features/work-items/get-work-item-comments/feature.ts
@@ -1,0 +1,58 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  CommentExpandOptions,
+  CommentList,
+  CommentSortOrder,
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+import { GetWorkItemCommentsOptions } from '../types';
+
+/**
+ * Get comments from a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param project The ID or name of the project
+ * @param workItemId The ID of the work item
+ * @param options Options for filtering comments
+ * @returns List of comments with pagination support
+ */
+export async function getWorkItemComments(
+  connection: WebApi,
+  project: string,
+  workItemId: number,
+  options: GetWorkItemCommentsOptions = {},
+): Promise<CommentList> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+
+    const order =
+      options.order === 'asc'
+        ? CommentSortOrder.Asc
+        : options.order === 'desc'
+          ? CommentSortOrder.Desc
+          : undefined;
+
+    const expand = options.includeRenderedText
+      ? CommentExpandOptions.RenderedText
+      : CommentExpandOptions.None;
+
+    const comments = await witApi.getComments(
+      project,
+      workItemId,
+      options.top,
+      options.continuationToken,
+      undefined, // includeDeleted
+      expand,
+      order,
+    );
+
+    return comments;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to get work item comments: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/get-work-item-comments/index.ts
+++ b/src/features/work-items/get-work-item-comments/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -8,6 +8,8 @@ export * from './get-work-item';
 export * from './create-work-item';
 export * from './update-work-item';
 export * from './manage-work-item-link';
+export * from './get-work-item-comments';
+export * from './add-work-item-comment';
 
 // Export tool definitions
 export * from './tool-definitions';
@@ -26,11 +28,15 @@ import {
   CreateWorkItemSchema,
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
+  GetWorkItemCommentsSchema,
+  AddWorkItemCommentSchema,
   listWorkItems,
   getWorkItem,
   createWorkItem,
   updateWorkItem,
   manageWorkItemLink,
+  getWorkItemComments,
+  addWorkItemComment,
 } from './';
 
 // Define the response type based on observed usage
@@ -51,6 +57,8 @@ export const isWorkItemsRequest: RequestIdentifier = (
     'create_work_item',
     'update_work_item',
     'manage_work_item_link',
+    'get_work_item_comments',
+    'add_work_item_comment',
   ].includes(toolName);
 };
 
@@ -137,6 +145,35 @@ export const handleWorkItemsRequest: RequestHandler = async (
           newRelationType: args.newRelationType,
           comment: args.comment,
         },
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_work_item_comments': {
+      const args = GetWorkItemCommentsSchema.parse(request.params.arguments);
+      const result = await getWorkItemComments(
+        connection,
+        args.projectId ?? defaultProject,
+        args.workItemId,
+        {
+          top: args.top,
+          continuationToken: args.continuationToken,
+          order: args.order,
+          includeRenderedText: args.includeRenderedText,
+        },
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'add_work_item_comment': {
+      const args = AddWorkItemCommentSchema.parse(request.params.arguments);
+      const result = await addWorkItemComment(
+        connection,
+        args.projectId ?? defaultProject,
+        args.workItemId,
+        args.text,
       );
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -117,6 +117,50 @@ export const UpdateWorkItemSchema = z.object({
 });
 
 /**
+ * Schema for getting work item comments
+ */
+export const GetWorkItemCommentsSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  workItemId: z.number().describe('The ID of the work item'),
+  top: z.number().optional().describe('Maximum number of comments to return'),
+  continuationToken: z
+    .string()
+    .optional()
+    .describe('Continuation token for pagination'),
+  order: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe('Sort order for comments (asc or desc)'),
+  includeRenderedText: z
+    .boolean()
+    .optional()
+    .describe('Include rendered HTML in addition to markdown'),
+});
+
+/**
+ * Schema for adding a comment to a work item
+ */
+export const AddWorkItemCommentSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  workItemId: z.number().describe('The ID of the work item'),
+  text: z.string().describe('The comment text (markdown supported)'),
+});
+
+/**
  * Schema for managing work item links
  */
 export const ManageWorkItemLinkSchema = z.object({

--- a/src/features/work-items/tool-definitions.ts
+++ b/src/features/work-items/tool-definitions.ts
@@ -6,6 +6,8 @@ import {
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   GetWorkItemSchema,
+  GetWorkItemCommentsSchema,
+  AddWorkItemCommentSchema,
 } from './schemas';
 
 /**
@@ -36,5 +38,16 @@ export const workItemsTools: ToolDefinition[] = [
     name: 'manage_work_item_link',
     description: 'Add or remove links between work items',
     inputSchema: zodToJsonSchema(ManageWorkItemLinkSchema),
+  },
+  {
+    name: 'get_work_item_comments',
+    description:
+      'Get comments from a work item. Supports pagination and sorting.',
+    inputSchema: zodToJsonSchema(GetWorkItemCommentsSchema),
+  },
+  {
+    name: 'add_work_item_comment',
+    description: 'Add a comment to a work item (markdown supported)',
+    inputSchema: zodToJsonSchema(AddWorkItemCommentSchema),
   },
 ];

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -43,5 +43,15 @@ export interface UpdateWorkItemOptions {
   additionalFields?: Record<string, string | number | boolean | null>;
 }
 
+/**
+ * Options for getting work item comments
+ */
+export interface GetWorkItemCommentsOptions {
+  top?: number;
+  continuationToken?: string;
+  order?: 'asc' | 'desc';
+  includeRenderedText?: boolean;
+}
+
 // Re-export WorkItem and WorkItemReference types for convenience
 export type { WorkItem, WorkItemReference };


### PR DESCRIPTION
## Summary

Adds two new tools for work item comment management, filling a gap where PR comments were supported but work item comments were not:

- **`get_work_item_comments`** — List comments on a work item with pagination (`top`/`continuationToken`), sort order (`asc`/`desc`), and optional rendered HTML output
- **`add_work_item_comment`** — Post a markdown comment to a work item

## Implementation

Uses the Work Item Tracking API's comments endpoint via `azure-devops-node-api` (`witApi.getComments` / `witApi.addComment`). Follows the same pattern as the existing PR comment tools (`get_pull_request_comments` / `add_pull_request_comment`).

### Files changed

- `src/features/work-items/get-work-item-comments/feature.ts` — `getWorkItemComments()` implementation
- `src/features/work-items/add-work-item-comment/feature.ts` — `addWorkItemComment()` implementation  
- `src/features/work-items/schemas.ts` — `GetWorkItemCommentsSchema` and `AddWorkItemCommentSchema`
- `src/features/work-items/types.ts` — `GetWorkItemCommentsOptions` interface
- `src/features/work-items/tool-definitions.ts` — Tool registration
- `src/features/work-items/index.ts` — Exports and request handler wiring

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 369 existing unit tests pass
- [x] Tested live against Azure DevOps — successfully retrieved comments from work item and posted new comments