### PR TITLE
feat(list-work-items): add fields option for additional field selection

### DIFF
--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -82,6 +82,7 @@ export const handleWorkItemsRequest: RequestHandler = async (
         wiql: args.wiql,
         top: args.top,
         skip: args.skip,
+        fields: args.fields,
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],

--- a/src/features/work-items/list-work-items/feature.spec.unit.ts
+++ b/src/features/work-items/list-work-items/feature.spec.unit.ts
@@ -121,4 +121,105 @@ describe('listWorkItems unit', () => {
       listWorkItems(mockConnection, { projectId: 'test-project' }),
     ).rejects.toThrow('Failed to list work items: Unexpected error');
   });
+
+  test('should request only default fields when no fields option is provided', async () => {
+    // Arrange
+    const mockWorkItemRefs = [{ id: 1 }];
+    const mockWorkItems = [{ id: 1, fields: { 'System.Title': 'Item 1' } }];
+    const mockGetWorkItems = jest.fn().mockResolvedValue(mockWorkItems);
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => ({
+        queryByWiql: jest
+          .fn()
+          .mockResolvedValue({ workItems: mockWorkItemRefs }),
+        getWorkItems: mockGetWorkItems,
+      })),
+    };
+
+    // Act
+    await listWorkItems(mockConnection, { projectId: 'test-project' });
+
+    // Assert: getWorkItems called with exactly the 4 default fields
+    const calledFields = mockGetWorkItems.mock.calls[0][1];
+    expect(calledFields).toEqual([
+      'System.Id',
+      'System.Title',
+      'System.State',
+      'System.AssignedTo',
+    ]);
+  });
+
+  test('should include additional fields alongside the defaults when fields option is provided', async () => {
+    // Arrange
+    const mockWorkItemRefs = [{ id: 1 }];
+    const mockWorkItems = [
+      {
+        id: 1,
+        fields: {
+          'System.Title': 'Item 1',
+          'Microsoft.VSTS.Scheduling.StoryPoints': 5,
+          'System.IterationPath': 'MyProject\\Sprint 1',
+        },
+      },
+    ];
+    const mockGetWorkItems = jest.fn().mockResolvedValue(mockWorkItems);
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => ({
+        queryByWiql: jest
+          .fn()
+          .mockResolvedValue({ workItems: mockWorkItemRefs }),
+        getWorkItems: mockGetWorkItems,
+      })),
+    };
+
+    // Act
+    const result = await listWorkItems(mockConnection, {
+      projectId: 'test-project',
+      fields: ['Microsoft.VSTS.Scheduling.StoryPoints', 'System.IterationPath'],
+    });
+
+    // Assert: getWorkItems was called with both default and requested fields (no duplicates)
+    const calledFields = mockGetWorkItems.mock.calls[0][1];
+    expect(calledFields).toContain('System.Id');
+    expect(calledFields).toContain('System.Title');
+    expect(calledFields).toContain('System.State');
+    expect(calledFields).toContain('System.AssignedTo');
+    expect(calledFields).toContain('Microsoft.VSTS.Scheduling.StoryPoints');
+    expect(calledFields).toContain('System.IterationPath');
+    expect(calledFields.length).toBe(6); // 4 defaults + 2 extra, no duplicates
+
+    // Assert: the extra field values are present in the returned items
+    expect(result[0].fields?.['Microsoft.VSTS.Scheduling.StoryPoints']).toBe(5);
+    expect(result[0].fields?.['System.IterationPath']).toBe(
+      'MyProject\\Sprint 1',
+    );
+  });
+
+  test('should deduplicate fields when a requested field overlaps with a default field', async () => {
+    // Arrange
+    const mockWorkItemRefs = [{ id: 1 }];
+    const mockWorkItems = [{ id: 1, fields: { 'System.Title': 'Item 1' } }];
+    const mockGetWorkItems = jest.fn().mockResolvedValue(mockWorkItems);
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => ({
+        queryByWiql: jest
+          .fn()
+          .mockResolvedValue({ workItems: mockWorkItemRefs }),
+        getWorkItems: mockGetWorkItems,
+      })),
+    };
+
+    // Act
+    await listWorkItems(mockConnection, {
+      projectId: 'test-project',
+      fields: ['System.Title', 'System.State'], // Both are already defaults
+    });
+
+    // Assert: no duplicates — still only 4 fields
+    const calledFields = mockGetWorkItems.mock.calls[0][1];
+    expect(calledFields.length).toBe(4);
+  });
 });

--- a/src/features/work-items/list-work-items/feature.ts
+++ b/src/features/work-items/list-work-items/feature.ts
@@ -74,12 +74,15 @@ export async function listWorkItems(
       return [];
     }
 
-    const fields = [
+    const defaultFields = [
       'System.Id',
       'System.Title',
       'System.State',
       'System.AssignedTo',
     ];
+    const fields = options.fields
+      ? [...new Set([...defaultFields, ...options.fields])]
+      : defaultFields;
     const workItems = await witApi.getWorkItems(
       workItemIds,
       fields,

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -31,6 +31,15 @@ export const ListWorkItemsSchema = z.object({
   wiql: z.string().optional().describe('Work Item Query Language (WIQL) query'),
   top: z.number().optional().describe('Maximum number of work items to return'),
   skip: z.number().optional().describe('Number of work items to skip'),
+  fields: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'List of additional fields to include in the response beyond the defaults ' +
+        '(System.Id, System.Title, System.State, System.AssignedTo). ' +
+        'Use full field reference names, e.g. "Microsoft.VSTS.Scheduling.StoryPoints", ' +
+        '"System.IterationPath", "System.AreaPath".',
+    ),
 });
 
 /**

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -13,6 +13,8 @@ export interface ListWorkItemsOptions {
   wiql?: string;
   top?: number;
   skip?: number;
+  /** Additional fields to include beyond the default four (Id, Title, State, AssignedTo). */
+  fields?: string[];
 }
 
 /**


### PR DESCRIPTION
Add an optional 'fields' parameter to list_work_items that lets callers request extra fields (e.g. StoryPoints, IterationPath) beyond the four defaults (Id, Title, State, AssignedTo).

Previously the fields passed to the ADO getWorkItems API were hardcoded, meaning SP and other fields were always absent regardless of what the caller requested. The only workaround was N individual get_work_item calls or raw REST API calls.

Changes:
- schemas.ts: add optional fields: string[] to ListWorkItemsSchema
- types.ts: add fields?: string[] to ListWorkItemsOptions interface
- feature.ts: merge caller fields with defaults (Set for dedup)
- index.ts: pass args.fields through to listWorkItems options
- feature.spec.unit.ts: 3 new tests covering default-only, extra fields, and deduplication behaviour

Fully backwards-compatible — existing callers unaffected.