### PR TITLE
fixing issue (#271): add severity parameter to resolve ignored seve…

### DIFF
--- a/src/features/work-items/create-work-item/feature.spec.unit.ts
+++ b/src/features/work-items/create-work-item/feature.spec.unit.ts
@@ -60,4 +60,56 @@ describe('createWorkItem unit', () => {
       }),
     ).rejects.toThrow('Failed to create work item: Unexpected error');
   });
+
+  test('should include severity field in patch document when severity is provided', async () => {
+    // Arrange
+    const mockWorkItem = { id: 1, fields: { 'System.Title': 'Test Bug' } };
+    const mockCreateWorkItem = jest.fn().mockResolvedValue(mockWorkItem);
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        createWorkItem: mockCreateWorkItem,
+      }),
+    };
+
+    // Act
+    await createWorkItem(mockConnection, 'TestProject', 'Bug', {
+      title: 'Test Bug',
+      severity: '1 - Critical',
+    });
+
+    // Assert: the patch document sent to ADO must include the Severity field
+    const patchDocument: Array<{ path: string; value: unknown }> =
+      mockCreateWorkItem.mock.calls[0][1];
+    const severityOp = patchDocument.find(
+      (op) => op.path === '/fields/Microsoft.VSTS.Common.Severity',
+    );
+    expect(severityOp).toBeDefined();
+    expect(severityOp?.value).toBe('1 - Critical');
+  });
+
+  test('should not include severity field in patch document when severity is omitted', async () => {
+    // Arrange
+    const mockWorkItem = { id: 1, fields: { 'System.Title': 'Test Task' } };
+    const mockCreateWorkItem = jest.fn().mockResolvedValue(mockWorkItem);
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        createWorkItem: mockCreateWorkItem,
+      }),
+    };
+
+    // Act
+    await createWorkItem(mockConnection, 'TestProject', 'Task', {
+      title: 'Test Task',
+    });
+
+    // Assert: patch document must NOT contain a Severity entry
+    const patchDocument: Array<{ path: string }> =
+      mockCreateWorkItem.mock.calls[0][1];
+    const severityOp = patchDocument.find(
+      (op) => op.path === '/fields/Microsoft.VSTS.Common.Severity',
+    );
+    expect(severityOp).toBeUndefined();
+  });
 });

--- a/src/features/work-items/create-work-item/feature.ts
+++ b/src/features/work-items/create-work-item/feature.ts
@@ -75,6 +75,14 @@ export async function createWorkItem(
       });
     }
 
+    if (options.severity !== undefined) {
+      document.push({
+        op: 'add',
+        path: '/fields/Microsoft.VSTS.Common.Severity',
+        value: options.severity,
+      });
+    }
+
     // Add parent relationship if parentId is provided
     if (options.parentId) {
       document.push({

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -100,6 +100,7 @@ export const handleWorkItemsRequest: RequestHandler = async (
           areaPath: args.areaPath,
           iterationPath: args.iterationPath,
           priority: args.priority,
+          severity: args.severity,
           parentId: args.parentId,
           additionalFields: args.additionalFields,
         },

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -67,6 +67,13 @@ export const CreateWorkItemSchema = z.object({
     .optional()
     .describe('The iteration path for the work item'),
   priority: z.number().optional().describe('The priority of the work item'),
+  severity: z
+    .string()
+    .optional()
+    .describe(
+      'The severity of the work item. Accepted values: "1 - Critical", "2 - High", ' +
+        '"3 - Medium", "4 - Low". Applies to work item types that support the Severity field (e.g. Bug).',
+    ),
   parentId: z
     .number()
     .optional()

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -25,6 +25,7 @@ export interface CreateWorkItemOptions {
   areaPath?: string;
   iterationPath?: string;
   priority?: number;
+  severity?: string;
   parentId?: number;
   additionalFields?: Record<string, string | number | boolean | null>;
 }


### PR DESCRIPTION
Severity bug

Fixes #271

The severity field was never exposed as a named parameter on create_work_item. Any severity value passed by the user was silently dropped and Azure DevOps defaulted to '3 - Medium' every time.

Root cause: CreateWorkItemSchema had no severity field. The fix adds it as an optional string parameter and wires it through to the ADO patch document as Microsoft.VSTS.Common.Severity.

Changes:
- schemas.ts: add optional severity: string to CreateWorkItemSchema with accepted values documented ('1 - Critical' through '4 - Low')
- types.ts: add severity?: string to CreateWorkItemOptions interface
- feature.ts: push Microsoft.VSTS.Common.Severity to patch document when set
- index.ts: pass args.severity through to createWorkItem options
- feature.spec.unit.ts: 2 new tests verifying severity is included in the patch document when provided, and absent when omitted

Fully backwards-compatible.