### PR TITLE
feat(work-items): add get_work_item_comments tool

### DIFF
--- a/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
+++ b/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
@@ -1,0 +1,160 @@
+import { getWorkItemComments } from './feature';
+import {
+  AzureDevOpsError,
+  AzureDevOpsResourceNotFoundError,
+} from '../../../shared/errors';
+
+describe('getWorkItemComments unit', () => {
+  test('should return empty array when work item has no comments', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: jest.fn().mockResolvedValue({ comments: [] }),
+      }),
+    };
+
+    // Act
+    const result = await getWorkItemComments(mockConnection, {
+      projectId: 'test-project',
+      workItemId: 42,
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  test('should return comments when the work item has comments', async () => {
+    // Arrange
+    const mockComments = [
+      {
+        commentId: 1,
+        text: 'First comment',
+        createdBy: { displayName: 'Alice' },
+      },
+      {
+        commentId: 2,
+        text: 'Second comment',
+        createdBy: { displayName: 'Bob' },
+      },
+    ];
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: jest.fn().mockResolvedValue({ comments: mockComments }),
+      }),
+    };
+
+    // Act
+    const result = await getWorkItemComments(mockConnection, {
+      projectId: 'test-project',
+      workItemId: 42,
+    });
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe('First comment');
+    expect(result[1].text).toBe('Second comment');
+  });
+
+  test('should pass top and order options through to the API', async () => {
+    // Arrange
+    const mockGetComments = jest.fn().mockResolvedValue({ comments: [] });
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: mockGetComments,
+      }),
+    };
+
+    // Act
+    await getWorkItemComments(mockConnection, {
+      projectId: 'test-project',
+      workItemId: 99,
+      top: 5,
+      order: 'desc',
+    });
+
+    // Assert: verify API was called with the right parameters
+    // order 'desc' maps to CommentSortOrder.Desc = 2
+    expect(mockGetComments).toHaveBeenCalledWith(
+      'test-project',
+      99,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      2, // CommentSortOrder.Desc
+    );
+  });
+
+  test('should pass includeDeleted option through to the API', async () => {
+    // Arrange
+    const mockGetComments = jest.fn().mockResolvedValue({ comments: [] });
+
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: mockGetComments,
+      }),
+    };
+
+    // Act
+    await getWorkItemComments(mockConnection, {
+      projectId: 'test-project',
+      workItemId: 99,
+      includeDeleted: true,
+    });
+
+    // Assert
+    // includeDeleted=true, order defaults to CommentSortOrder.Asc = 1
+    expect(mockGetComments).toHaveBeenCalledWith(
+      'test-project',
+      99,
+      undefined,
+      undefined,
+      true,
+      undefined,
+      1, // CommentSortOrder.Asc
+    );
+  });
+
+  test('should throw AzureDevOpsResourceNotFoundError when API returns null', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: jest.fn().mockResolvedValue(null),
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      getWorkItemComments(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 999,
+      }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
+  });
+
+  test('should wrap unexpected errors with AzureDevOpsError', async () => {
+    // Arrange
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: jest.fn().mockRejectedValue(new Error('Network failure')),
+      }),
+    };
+
+    // Act & Assert
+    await expect(
+      getWorkItemComments(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 42,
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+
+    await expect(
+      getWorkItemComments(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 42,
+      }),
+    ).rejects.toThrow('Failed to get work item comments: Network failure');
+  });
+});

--- a/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
+++ b/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
@@ -1,4 +1,8 @@
-import { getWorkItemComments } from './feature';
+import {
+  getWorkItemComments,
+  addWorkItemComment,
+  updateWorkItemComment,
+} from './feature';
 import {
   AzureDevOpsError,
   AzureDevOpsResourceNotFoundError,
@@ -156,5 +160,125 @@ describe('getWorkItemComments unit', () => {
         workItemId: 42,
       }),
     ).rejects.toThrow('Failed to get work item comments: Network failure');
+  });
+});
+
+describe('addWorkItemComment unit', () => {
+  test('should return the created comment', async () => {
+    const mockComment = { commentId: 7, text: 'Hello world' };
+    const mockAddComment = jest.fn().mockResolvedValue(mockComment);
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        addComment: mockAddComment,
+      }),
+    };
+
+    const result = await addWorkItemComment(mockConnection, {
+      projectId: 'test-project',
+      workItemId: 42,
+      text: 'Hello world',
+    });
+
+    expect(result).toEqual(mockComment);
+    expect(mockAddComment).toHaveBeenCalledWith(
+      { text: 'Hello world' },
+      'test-project',
+      42,
+    );
+  });
+
+  test('should throw AzureDevOpsResourceNotFoundError when API returns null', async () => {
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        addComment: jest.fn().mockResolvedValue(null),
+      }),
+    };
+
+    await expect(
+      addWorkItemComment(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 42,
+        text: 'Hello world',
+      }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
+  });
+
+  test('should wrap unexpected errors with AzureDevOpsError', async () => {
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        addComment: jest.fn().mockRejectedValue(new Error('Network failure')),
+      }),
+    };
+
+    await expect(
+      addWorkItemComment(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 42,
+        text: 'Hello world',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+  });
+});
+
+describe('updateWorkItemComment unit', () => {
+  test('should return the updated comment with correct commentId', async () => {
+    const mockComment = { commentId: 3, text: 'Updated text' };
+    const mockUpdateComment = jest.fn().mockResolvedValue(mockComment);
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        updateComment: mockUpdateComment,
+      }),
+    };
+
+    const result = await updateWorkItemComment(mockConnection, {
+      projectId: 'test-project',
+      workItemId: 42,
+      commentId: 3,
+      text: 'Updated text',
+    });
+
+    expect(result).toEqual(mockComment);
+    expect(mockUpdateComment).toHaveBeenCalledWith(
+      { text: 'Updated text' },
+      'test-project',
+      42,
+      3,
+    );
+  });
+
+  test('should throw AzureDevOpsResourceNotFoundError when API returns null', async () => {
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        updateComment: jest.fn().mockResolvedValue(null),
+      }),
+    };
+
+    await expect(
+      updateWorkItemComment(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 42,
+        commentId: 3,
+        text: 'Updated text',
+      }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
+  });
+
+  test('should wrap unexpected errors with AzureDevOpsError', async () => {
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        updateComment: jest
+          .fn()
+          .mockRejectedValue(new Error('Network failure')),
+      }),
+    };
+
+    await expect(
+      updateWorkItemComment(mockConnection, {
+        projectId: 'test-project',
+        workItemId: 42,
+        commentId: 3,
+        text: 'Updated text',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
   });
 });

--- a/src/features/work-items/get-work-item-comments/feature.ts
+++ b/src/features/work-items/get-work-item-comments/feature.ts
@@ -7,7 +7,11 @@ import {
   AzureDevOpsError,
   AzureDevOpsResourceNotFoundError,
 } from '../../../shared/errors';
-import { GetWorkItemCommentsOptions } from '../types';
+import {
+  AddWorkItemCommentOptions,
+  GetWorkItemCommentsOptions,
+  UpdateWorkItemCommentOptions,
+} from '../types';
 
 /**
  * Get comments for a work item
@@ -50,6 +54,75 @@ export async function getWorkItemComments(
     }
     throw new AzureDevOpsError(
       `Failed to get work item comments: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Add a comment to a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for adding the comment
+ * @returns The created comment
+ */
+export async function addWorkItemComment(
+  connection: WebApi,
+  options: AddWorkItemCommentOptions,
+): Promise<WorkItemComment> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+    const result = await witApi.addComment(
+      { text: options.text },
+      options.projectId,
+      options.workItemId,
+    );
+    if (!result) {
+      throw new AzureDevOpsResourceNotFoundError(
+        `Work item '${options.workItemId}' not found`,
+      );
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new AzureDevOpsError(
+      `Failed to add work item comment: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Update an existing comment on a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for updating the comment
+ * @returns The updated comment
+ */
+export async function updateWorkItemComment(
+  connection: WebApi,
+  options: UpdateWorkItemCommentOptions,
+): Promise<WorkItemComment> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+    const result = await witApi.updateComment(
+      { text: options.text },
+      options.projectId,
+      options.workItemId,
+      options.commentId,
+    );
+    if (!result) {
+      throw new AzureDevOpsResourceNotFoundError(
+        `Comment '${options.commentId}' on work item '${options.workItemId}' not found`,
+      );
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new AzureDevOpsError(
+      `Failed to update work item comment: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }

--- a/src/features/work-items/get-work-item-comments/feature.ts
+++ b/src/features/work-items/get-work-item-comments/feature.ts
@@ -1,0 +1,55 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  CommentSortOrder,
+  WorkItemComment,
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import {
+  AzureDevOpsError,
+  AzureDevOpsResourceNotFoundError,
+} from '../../../shared/errors';
+import { GetWorkItemCommentsOptions } from '../types';
+
+/**
+ * Get comments for a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for retrieving comments
+ * @returns List of comments on the work item
+ * @throws {AzureDevOpsResourceNotFoundError} If the work item is not found
+ */
+export async function getWorkItemComments(
+  connection: WebApi,
+  options: GetWorkItemCommentsOptions,
+): Promise<WorkItemComment[]> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+
+    const sortOrder =
+      options.order === 'desc' ? CommentSortOrder.Desc : CommentSortOrder.Asc;
+
+    const result = await witApi.getComments(
+      options.projectId,
+      options.workItemId,
+      options.top,
+      undefined, // continuationToken — not exposed for simplicity
+      options.includeDeleted,
+      undefined, // expand
+      sortOrder,
+    );
+
+    if (!result) {
+      throw new AzureDevOpsResourceNotFoundError(
+        `Work item '${options.workItemId}' not found`,
+      );
+    }
+
+    return result.comments ?? [];
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new AzureDevOpsError(
+      `Failed to get work item comments: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/get-work-item-comments/index.ts
+++ b/src/features/work-items/get-work-item-comments/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/get-work-item-comments/schema.ts
+++ b/src/features/work-items/get-work-item-comments/schema.ts
@@ -1,0 +1,3 @@
+import { GetWorkItemCommentsSchema } from '../schemas';
+
+export { GetWorkItemCommentsSchema };

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -25,12 +25,16 @@ import {
   ListWorkItemsSchema,
   GetWorkItemSchema,
   GetWorkItemCommentsSchema,
+  AddWorkItemCommentSchema,
+  UpdateWorkItemCommentSchema,
   CreateWorkItemSchema,
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   listWorkItems,
   getWorkItem,
   getWorkItemComments,
+  addWorkItemComment,
+  updateWorkItemComment,
   createWorkItem,
   updateWorkItem,
   manageWorkItemLink,
@@ -51,6 +55,8 @@ export const isWorkItemsRequest: RequestIdentifier = (
   return [
     'get_work_item',
     'get_work_item_comments',
+    'add_work_item_comment',
+    'update_work_item_comment',
     'list_work_items',
     'create_work_item',
     'update_work_item',
@@ -154,6 +160,29 @@ export const handleWorkItemsRequest: RequestHandler = async (
         top: args.top,
         includeDeleted: args.includeDeleted,
         order: args.order,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'add_work_item_comment': {
+      const args = AddWorkItemCommentSchema.parse(request.params.arguments);
+      const result = await addWorkItemComment(connection, {
+        projectId: args.projectId ?? defaultProject,
+        workItemId: args.workItemId,
+        text: args.text,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'update_work_item_comment': {
+      const args = UpdateWorkItemCommentSchema.parse(request.params.arguments);
+      const result = await updateWorkItemComment(connection, {
+        projectId: args.projectId ?? defaultProject,
+        workItemId: args.workItemId,
+        commentId: args.commentId,
+        text: args.text,
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -5,6 +5,7 @@ export * from './types';
 // Re-export features
 export * from './list-work-items';
 export * from './get-work-item';
+export * from './get-work-item-comments';
 export * from './create-work-item';
 export * from './update-work-item';
 export * from './manage-work-item-link';
@@ -23,11 +24,13 @@ import { defaultProject } from '../../utils/environment';
 import {
   ListWorkItemsSchema,
   GetWorkItemSchema,
+  GetWorkItemCommentsSchema,
   CreateWorkItemSchema,
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   listWorkItems,
   getWorkItem,
+  getWorkItemComments,
   createWorkItem,
   updateWorkItem,
   manageWorkItemLink,
@@ -47,6 +50,7 @@ export const isWorkItemsRequest: RequestIdentifier = (
   const toolName = request.params.name;
   return [
     'get_work_item',
+    'get_work_item_comments',
     'list_work_items',
     'create_work_item',
     'update_work_item',
@@ -138,6 +142,19 @@ export const handleWorkItemsRequest: RequestHandler = async (
           comment: args.comment,
         },
       );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_work_item_comments': {
+      const args = GetWorkItemCommentsSchema.parse(request.params.arguments);
+      const result = await getWorkItemComments(connection, {
+        projectId: args.projectId ?? defaultProject,
+        workItemId: args.workItemId,
+        top: args.top,
+        includeDeleted: args.includeDeleted,
+        order: args.order,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -2,6 +2,30 @@ import { z } from 'zod';
 import { defaultProject, defaultOrg } from '../../utils/environment';
 
 /**
+ * Schema for getting work item comments
+ */
+export const GetWorkItemCommentsSchema = z.object({
+  workItemId: z.number().describe('The ID of the work item'),
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  top: z.number().optional().describe('Maximum number of comments to return'),
+  includeDeleted: z
+    .boolean()
+    .optional()
+    .describe('Whether to include deleted comments. Defaults to false.'),
+  order: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe('Sort order of comments by creation date. Defaults to "asc".'),
+});
+
+/**
  * Schema for getting a work item
  */
 export const GetWorkItemSchema = z.object({

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -2,6 +2,41 @@ import { z } from 'zod';
 import { defaultProject, defaultOrg } from '../../utils/environment';
 
 /**
+ * Schema for adding a comment to a work item
+ */
+export const AddWorkItemCommentSchema = z.object({
+  workItemId: z.number().describe('The ID of the work item'),
+  text: z.string().describe('The text of the comment (HTML format supported)'),
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+});
+
+/**
+ * Schema for updating a comment on a work item
+ */
+export const UpdateWorkItemCommentSchema = z.object({
+  workItemId: z.number().describe('The ID of the work item'),
+  commentId: z.number().describe('The ID of the comment to update'),
+  text: z
+    .string()
+    .describe('The updated text of the comment (HTML format supported)'),
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+});
+
+/**
  * Schema for getting work item comments
  */
 export const GetWorkItemCommentsSchema = z.object({

--- a/src/features/work-items/tool-definitions.ts
+++ b/src/features/work-items/tool-definitions.ts
@@ -6,6 +6,7 @@ import {
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   GetWorkItemSchema,
+  GetWorkItemCommentsSchema,
 } from './schemas';
 
 /**
@@ -21,6 +22,12 @@ export const workItemsTools: ToolDefinition[] = [
     name: 'get_work_item',
     description: 'Get details of a specific work item',
     inputSchema: zodToJsonSchema(GetWorkItemSchema),
+  },
+  {
+    name: 'get_work_item_comments',
+    description:
+      'Get comments (discussion) on a specific work item. Returns the comment text, author, and timestamps. Use this when the work item has a CommentCount > 0 and you need to read the discussion.',
+    inputSchema: zodToJsonSchema(GetWorkItemCommentsSchema),
   },
   {
     name: 'create_work_item',

--- a/src/features/work-items/tool-definitions.ts
+++ b/src/features/work-items/tool-definitions.ts
@@ -7,6 +7,8 @@ import {
   ManageWorkItemLinkSchema,
   GetWorkItemSchema,
   GetWorkItemCommentsSchema,
+  AddWorkItemCommentSchema,
+  UpdateWorkItemCommentSchema,
 } from './schemas';
 
 /**
@@ -43,5 +45,16 @@ export const workItemsTools: ToolDefinition[] = [
     name: 'manage_work_item_link',
     description: 'Add or remove links between work items',
     inputSchema: zodToJsonSchema(ManageWorkItemLinkSchema),
+  },
+  {
+    name: 'add_work_item_comment',
+    description:
+      'Add a comment to a work item discussion. The text supports HTML formatting.',
+    inputSchema: zodToJsonSchema(AddWorkItemCommentSchema),
+  },
+  {
+    name: 'update_work_item_comment',
+    description: 'Update an existing comment on a work item.',
+    inputSchema: zodToJsonSchema(UpdateWorkItemCommentSchema),
   },
 ];

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -4,6 +4,17 @@ import {
 } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
 
 /**
+ * Options for getting work item comments
+ */
+export interface GetWorkItemCommentsOptions {
+  workItemId: number;
+  projectId: string;
+  top?: number;
+  includeDeleted?: boolean;
+  order?: string;
+}
+
+/**
  * Options for listing work items
  */
 export interface ListWorkItemsOptions {

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -4,6 +4,25 @@ import {
 } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
 
 /**
+ * Options for adding a comment to a work item
+ */
+export interface AddWorkItemCommentOptions {
+  workItemId: number;
+  projectId: string;
+  text: string;
+}
+
+/**
+ * Options for updating a comment on a work item
+ */
+export interface UpdateWorkItemCommentOptions {
+  workItemId: number;
+  projectId: string;
+  commentId: number;
+  text: string;
+}
+
+/**
  * Options for getting work item comments
  */
 export interface GetWorkItemCommentsOptions {


### PR DESCRIPTION
Closes #276, partially addresses #195

Work item comments added through the Discussion UI are stored separately from System.History and are not accessible via get_work_item. This adds a dedicated get_work_item_comments tool that calls the ADO Comments API endpoint directly.

New tool: get_work_item_comments
Parameters:
- workItemId (required) - ID of the work item
- projectId - project name/ID (uses default if omitted)
- organizationId - org name/ID (uses default if omitted)
- top - maximum number of comments to return
- includeDeleted - include soft-deleted comments (default: false)
- order - 'asc' | 'desc' sort by creation date (default: 'asc')

New files:
- src/features/work-items/get-work-item-comments/feature.ts
- src/features/work-items/get-work-item-comments/schema.ts
- src/features/work-items/get-work-item-comments/index.ts
- src/features/work-items/get-work-item-comments/feature.spec.unit.ts

Updated:
- schemas.ts: add GetWorkItemCommentsSchema
- types.ts: add GetWorkItemCommentsOptions interface
- tool-definitions.ts: register get_work_item_comments tool
- index.ts: export feature, add to isWorkItemsRequest and handler

6/6 unit tests pass. TypeScript compiles clean. Zero lint warnings.