### PR TITLE
fix(pull-requests): update thread status when adding comment to existing thread

### DIFF
--- a/src/features/pull-requests/add-pull-request-comment/feature.ts
+++ b/src/features/pull-requests/add-pull-request-comment/feature.ts
@@ -12,6 +12,29 @@ import {
   transformCommentType,
 } from '../../../shared/enums';
 
+function parseThreadStatus(
+  status: string | undefined,
+): CommentThreadStatus | undefined {
+  switch (status) {
+    case 'active':
+      return CommentThreadStatus.Active;
+    case 'fixed':
+      return CommentThreadStatus.Fixed;
+    case 'wontFix':
+      return CommentThreadStatus.WontFix;
+    case 'closed':
+      return CommentThreadStatus.Closed;
+    case 'pending':
+      return CommentThreadStatus.Pending;
+    case 'byDesign':
+      return CommentThreadStatus.ByDesign;
+    case 'unknown':
+      return CommentThreadStatus.Unknown;
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Add a comment to a pull request
  *
@@ -66,42 +89,43 @@ export async function addPullRequestComment(
         throw new Error('Failed to create pull request comment');
       }
 
+      // Also update the thread status if one was specified
+      let updatedThread: GitPullRequestCommentThread | undefined;
+      if (options.status) {
+        const threadStatus = parseThreadStatus(options.status);
+
+        if (threadStatus !== undefined) {
+          updatedThread = await gitApi.updateThread(
+            { status: threadStatus },
+            resolvedRepositoryId,
+            pullRequestId,
+            options.threadId,
+            project,
+          );
+        }
+      }
+
       return {
         comment: {
           ...createdComment,
           commentType: transformCommentType(createdComment.commentType),
         },
+        ...(updatedThread && {
+          thread: {
+            ...updatedThread,
+            status: transformCommentThreadStatus(updatedThread.status),
+            comments: updatedThread.comments?.map((c) => ({
+              ...c,
+              commentType: transformCommentType(c.commentType),
+            })),
+          },
+        }),
       };
     }
     // Case 2: Create new thread with comment
     else {
       // Map status string to CommentThreadStatus enum
-      let threadStatus: CommentThreadStatus | undefined;
-      if (options.status) {
-        switch (options.status) {
-          case 'active':
-            threadStatus = CommentThreadStatus.Active;
-            break;
-          case 'fixed':
-            threadStatus = CommentThreadStatus.Fixed;
-            break;
-          case 'wontFix':
-            threadStatus = CommentThreadStatus.WontFix;
-            break;
-          case 'closed':
-            threadStatus = CommentThreadStatus.Closed;
-            break;
-          case 'pending':
-            threadStatus = CommentThreadStatus.Pending;
-            break;
-          case 'byDesign':
-            threadStatus = CommentThreadStatus.ByDesign;
-            break;
-          case 'unknown':
-            threadStatus = CommentThreadStatus.Unknown;
-            break;
-        }
-      }
+      const threadStatus = parseThreadStatus(options.status);
 
       // Create thread with comment
       const thread: GitPullRequestCommentThread = {


### PR DESCRIPTION
## Problem

When calling `add_pull_request_comment` with a `threadId` (to reply to an existing thread) **and** a `status` (e.g. `fixed`), the thread status was silently ignored. The `status` option was only wired up in the \"create new thread\" branch (Case 2), not in the \"add to existing thread\" branch (Case 1).

## Fix

In Case 1 (`threadId` is provided), after creating the comment, if a `status` was also specified, `gitApi.updateThread()` is now called to apply the status change. The updated thread is returned in the response alongside the comment — matching the shape already returned by Case 2.

## Before

```ts
// threadId provided + status: "fixed" → comment added, thread stays "active"
```

## After

```ts
// threadId provided + status: "fixed" → comment added AND thread set to "fixed"
```

## Testing

Verified manually against a self-hosted Azure DevOps instance by toggling a thread between `active` and `fixed` multiple times via the MCP tool and confirming the thread status in the API response and in the UI.