### PR TITLE
fix: resolve work item link removal issue (#296)

### DIFF
--- a/src/features/work-items/manage-work-item-link/feature.spec.int.ts
+++ b/src/features/work-items/manage-work-item-link/feature.spec.int.ts
@@ -80,6 +80,20 @@ describeOrSkip('manageWorkItemLink integration', () => {
     expect(result.id).toBe(sourceWorkItemId);
   });
 
+  test('should remove a link between two existing work items', async () => {
+    // Act & Assert - should not throw
+    const result = await manageWorkItemLink(connection, projectName, {
+      sourceWorkItemId,
+      targetWorkItemId,
+      operation: 'remove',
+      relationType: 'System.LinkTypes.Related',
+    });
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.id).toBe(sourceWorkItemId);
+  });
+
   test('should handle non-existent work items gracefully', async () => {
     // Use a very large ID that's unlikely to exist
     const nonExistentId = 999999999;

--- a/src/features/work-items/manage-work-item-link/feature.spec.unit.ts
+++ b/src/features/work-items/manage-work-item-link/feature.spec.unit.ts
@@ -1,5 +1,6 @@
 import { manageWorkItemLink } from './feature';
 import { AzureDevOpsResourceNotFoundError } from '../../../shared/errors';
+import { WorkItemExpand } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
 
 describe('manageWorkItemLink', () => {
   let mockConnection: any;
@@ -15,6 +16,7 @@ describe('manageWorkItemLink', () => {
   beforeEach(() => {
     mockWitApi = {
       updateWorkItem: jest.fn(),
+      getWorkItem: jest.fn(),
     };
 
     mockConnection = {
@@ -67,6 +69,15 @@ describe('manageWorkItemLink', () => {
       id: sourceWorkItemId,
       fields: { 'System.Title': 'Test' },
     };
+    mockWitApi.getWorkItem.mockResolvedValue({
+      id: sourceWorkItemId,
+      relations: [
+        {
+          rel: relationType,
+          url: `${mockConnection.serverUrl}/_apis/wit/workItems/${targetWorkItemId}`,
+        },
+      ],
+    });
     mockWitApi.updateWorkItem.mockResolvedValue(updatedWorkItem);
 
     // Execute
@@ -79,12 +90,18 @@ describe('manageWorkItemLink', () => {
 
     // Verify
     expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalled();
+    expect(mockWitApi.getWorkItem).toHaveBeenCalledWith(
+      sourceWorkItemId,
+      undefined,
+      undefined,
+      WorkItemExpand.Relations,
+    );
     expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
       {}, // customHeaders
       [
         {
           op: 'remove',
-          path: `/relations/+[rel=${relationType};url=${mockConnection.serverUrl}/_apis/wit/workItems/${targetWorkItemId}]`,
+          path: '/relations/0',
         },
       ],
       sourceWorkItemId,
@@ -99,6 +116,15 @@ describe('manageWorkItemLink', () => {
       id: sourceWorkItemId,
       fields: { 'System.Title': 'Test' },
     };
+    mockWitApi.getWorkItem.mockResolvedValue({
+      id: sourceWorkItemId,
+      relations: [
+        {
+          rel: relationType,
+          url: `${mockConnection.serverUrl}/_apis/wit/workItems/${targetWorkItemId}`,
+        },
+      ],
+    });
     mockWitApi.updateWorkItem.mockResolvedValue(updatedWorkItem);
 
     // Execute
@@ -113,12 +139,18 @@ describe('manageWorkItemLink', () => {
 
     // Verify
     expect(mockConnection.getWorkItemTrackingApi).toHaveBeenCalled();
+    expect(mockWitApi.getWorkItem).toHaveBeenCalledWith(
+      sourceWorkItemId,
+      undefined,
+      undefined,
+      WorkItemExpand.Relations,
+    );
     expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
       {}, // customHeaders
       [
         {
           op: 'remove',
-          path: `/relations/+[rel=${relationType};url=${mockConnection.serverUrl}/_apis/wit/workItems/${targetWorkItemId}]`,
+          path: '/relations/0',
         },
         {
           op: 'add',
@@ -162,5 +194,28 @@ describe('manageWorkItemLink', () => {
         // newRelationType is missing
       }),
     ).rejects.toThrow('New relation type is required for update operation');
+  });
+
+  test('should throw error when relation to remove is not found', async () => {
+    // Setup
+    mockWitApi.getWorkItem.mockResolvedValue({
+      id: sourceWorkItemId,
+      relations: [
+        {
+          rel: 'Some.Other.LinkType',
+          url: `${mockConnection.serverUrl}/_apis/wit/workItems/999`,
+        },
+      ],
+    });
+
+    // Execute and verify
+    await expect(
+      manageWorkItemLink(mockConnection, projectId, {
+        sourceWorkItemId,
+        targetWorkItemId,
+        operation: 'remove',
+        relationType,
+      }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
   });
 });

--- a/src/features/work-items/manage-work-item-link/feature.ts
+++ b/src/features/work-items/manage-work-item-link/feature.ts
@@ -1,4 +1,5 @@
 import { WebApi } from 'azure-devops-node-api';
+import { WorkItemExpand } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
 import {
   AzureDevOpsResourceNotFoundError,
   AzureDevOpsError,
@@ -66,12 +67,44 @@ export async function manageWorkItemLink(
     // Construct the relationship URL
     const relationshipUrl = `${connection.serverUrl}/_apis/wit/workItems/${targetWorkItemId}`;
 
+    let relationIndex = -1;
+    if (operation === 'remove' || operation === 'update') {
+      const sourceWorkItem = await witApi.getWorkItem(
+        sourceWorkItemId,
+        undefined,
+        undefined,
+        WorkItemExpand.Relations,
+      );
+
+      if (!sourceWorkItem) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Work item '${sourceWorkItemId}' not found`,
+        );
+      }
+
+      const relations = sourceWorkItem.relations || [];
+      const targetSuffix =
+        `/_apis/wit/workItems/${targetWorkItemId}`.toLowerCase();
+
+      relationIndex = relations.findIndex(
+        (rel) =>
+          rel.rel?.toLowerCase() === relationType.toLowerCase() &&
+          rel.url?.toLowerCase().endsWith(targetSuffix),
+      );
+
+      if (relationIndex === -1) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Relation of type '${relationType}' to target work item '${targetWorkItemId}' not found on source work item '${sourceWorkItemId}'`,
+        );
+      }
+    }
+
     if (operation === 'add' || operation === 'update') {
       // For 'update', we'll first remove the old link, then add the new one
       if (operation === 'update') {
         document.push({
           op: 'remove',
-          path: `/relations/+[rel=${relationType};url=${relationshipUrl}]`,
+          path: `/relations/${relationIndex}`,
         });
       }
 
@@ -89,7 +122,7 @@ export async function manageWorkItemLink(
       // Remove the relationship
       document.push({
         op: 'remove',
-        path: `/relations/+[rel=${relationType};url=${relationshipUrl}]`,
+        path: `/relations/${relationIndex}`,
       });
     }
 


### PR DESCRIPTION
## Description
This Pull Request resolves Issue #296 where `manage_work_item_link` 'remove' fails with an error due to invalid relation path syntax.

### Changes
1. **Source Update (`src/features/work-items/manage-work-item-link/feature.ts`):**
   - Imported `WorkItemExpand` from `azure-devops-node-api/interfaces/WorkItemTrackingInterfaces`.
   - In `manageWorkItemLink` when the operation is `remove` or `update`, the source work item is fetched with relations using `witApi.getWorkItem(sourceWorkItemId, undefined, undefined, WorkItemExpand.Relations)`.
   - Looks up the 0-based index of the target relation within the relations array (matching `relationType` and targeting the correct `targetWorkItemId` case-insensitively).
   - If not found, throws a descriptive `AzureDevOpsResourceNotFoundError`.
   - Replaced the query-based relation path (`/relations/+[rel=...;url=...]`) with the index-based path (`/relations/${relationIndex}`) for the `remove` operations.

2. **Unit Tests (`src/features/work-items/manage-work-item-link/feature.spec.unit.ts`):**
   - Mocked `getWorkItem` to simulate source work item details containing relations.
   - Updated assertions to verify that `getWorkItem` is called with `WorkItemExpand.Relations` and that the patch document expects the index-based path.
   - Added test coverage for when the relation to remove is not found.

3. **Integration Tests (`src/features/work-items/manage-work-item-link/feature.spec.int.ts`):**
   - Added a new integration test case to verify that the `remove` operation executes successfully without throwing.