### PR TITLE
feat: add first-class tags management for work items (#297)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -248,7 +248,6 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2017,7 +2016,6 @@
       "integrity": "sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -2096,7 +2094,6 @@
       "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.27.0",
         "@typescript-eslint/types": "8.27.0",
@@ -2317,7 +2314,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2748,7 +2744,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3410,7 +3405,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4028,7 +4022,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5794,7 +5787,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9113,7 +9105,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9347,7 +9338,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9678,7 +9668,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/work-items/create-work-item/feature.spec.unit.ts
+++ b/src/features/work-items/create-work-item/feature.spec.unit.ts
@@ -60,4 +60,51 @@ describe('createWorkItem unit', () => {
       }),
     ).rejects.toThrow('Failed to create work item: Unexpected error');
   });
+
+  test('should include System.Tags patch entry when tags option is provided', async () => {
+    const mockCreateWorkItem = jest.fn().mockResolvedValue({ id: 1 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        createWorkItem: mockCreateWorkItem,
+      }),
+    };
+
+    await createWorkItem(mockConnection, 'TestProject', 'Task', {
+      title: 'Test Task',
+      tags: ['bug', 'frontend'],
+    });
+
+    expect(mockCreateWorkItem).toHaveBeenCalledWith(
+      null,
+      expect.arrayContaining([
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: 'bug; frontend',
+        },
+      ]),
+      'TestProject',
+      'Task',
+    );
+  });
+
+  test('should not include System.Tags patch entry when tags option is empty', async () => {
+    const mockCreateWorkItem = jest.fn().mockResolvedValue({ id: 1 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        createWorkItem: mockCreateWorkItem,
+      }),
+    };
+
+    await createWorkItem(mockConnection, 'TestProject', 'Task', {
+      title: 'Test Task',
+      tags: [],
+    });
+
+    const document = mockCreateWorkItem.mock.calls[0][1];
+    const tagsPatch = document.find(
+      (entry: any) => entry.path === '/fields/System.Tags',
+    );
+    expect(tagsPatch).toBeUndefined();
+  });
 });

--- a/src/features/work-items/create-work-item/feature.ts
+++ b/src/features/work-items/create-work-item/feature.ts
@@ -87,6 +87,15 @@ export async function createWorkItem(
       });
     }
 
+    // Add tags logic
+    if (options.tags && options.tags.length > 0) {
+      document.push({
+        op: 'add',
+        path: '/fields/System.Tags',
+        value: options.tags.join('; '),
+      });
+    }
+
     // Add any additional fields
     if (options.additionalFields) {
       for (const [key, value] of Object.entries(options.additionalFields)) {

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -101,6 +101,7 @@ export const handleWorkItemsRequest: RequestHandler = async (
           iterationPath: args.iterationPath,
           priority: args.priority,
           parentId: args.parentId,
+          tags: args.tags,
           additionalFields: args.additionalFields,
         },
       );
@@ -118,6 +119,9 @@ export const handleWorkItemsRequest: RequestHandler = async (
         iterationPath: args.iterationPath,
         priority: args.priority,
         state: args.state,
+        tags: args.tags,
+        tagsToAdd: args.tagsToAdd,
+        tagsToRemove: args.tagsToRemove,
         additionalFields: args.additionalFields,
       });
       return {

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -71,6 +71,7 @@ export const CreateWorkItemSchema = z.object({
     .number()
     .optional()
     .describe('The ID of the parent work item to create a relationship with'),
+  tags: z.array(z.string()).optional().describe('Tags to add to the work item'),
   additionalFields: z
     .record(z.string(), z.any())
     .optional()
@@ -108,6 +109,18 @@ export const UpdateWorkItemSchema = z.object({
     .optional()
     .describe('The updated priority of the work item'),
   state: z.string().optional().describe('The updated state of the work item'),
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe('Overwrite/set the complete set of tags'),
+  tagsToAdd: z
+    .array(z.string())
+    .optional()
+    .describe('List of tags to append to the work item'),
+  tagsToRemove: z
+    .array(z.string())
+    .optional()
+    .describe('List of tags to remove from the work item'),
   additionalFields: z
     .record(z.string(), z.any())
     .optional()

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -26,6 +26,7 @@ export interface CreateWorkItemOptions {
   iterationPath?: string;
   priority?: number;
   parentId?: number;
+  tags?: string[];
   additionalFields?: Record<string, string | number | boolean | null>;
 }
 
@@ -40,6 +41,9 @@ export interface UpdateWorkItemOptions {
   iterationPath?: string;
   priority?: number;
   state?: string;
+  tags?: string[];
+  tagsToAdd?: string[];
+  tagsToRemove?: string[];
   additionalFields?: Record<string, string | number | boolean | null>;
 }
 

--- a/src/features/work-items/update-work-item/feature.spec.int.ts
+++ b/src/features/work-items/update-work-item/feature.spec.int.ts
@@ -113,4 +113,37 @@ describeOrSkip('updateWorkItem integration', () => {
       updateWorkItem(connection, nonExistentId, options),
     ).rejects.toThrow(/Failed to update work item|not found/);
   });
+
+  test('should manage tags using first-class fields (tags, tagsToAdd, tagsToRemove)', async () => {
+    // 1. Overwrite tags
+    let result = await updateWorkItem(connection, createdWorkItemId, {
+      tags: ['A', 'B'],
+    });
+    expect(result.fields).toBeDefined();
+    expect(result.fields?.['System.Tags']).toBe('A; B');
+
+    // 2. Append tags
+    result = await updateWorkItem(connection, createdWorkItemId, {
+      tagsToAdd: ['B', 'C', 'D'],
+    });
+    expect(result.fields?.['System.Tags']).toContain('A');
+    expect(result.fields?.['System.Tags']).toContain('B');
+    expect(result.fields?.['System.Tags']).toContain('C');
+    expect(result.fields?.['System.Tags']).toContain('D');
+
+    // 3. Remove tags
+    result = await updateWorkItem(connection, createdWorkItemId, {
+      tagsToRemove: ['A', 'D', 'E'],
+    });
+    expect(result.fields?.['System.Tags']).not.toContain('A');
+    expect(result.fields?.['System.Tags']).toContain('B');
+    expect(result.fields?.['System.Tags']).toContain('C');
+    expect(result.fields?.['System.Tags']).not.toContain('D');
+
+    // 4. Overwrite to clear
+    result = await updateWorkItem(connection, createdWorkItemId, {
+      tags: [],
+    });
+    expect(result.fields?.['System.Tags'] || '').toBe('');
+  });
 });

--- a/src/features/work-items/update-work-item/feature.spec.unit.ts
+++ b/src/features/work-items/update-work-item/feature.spec.unit.ts
@@ -51,4 +51,140 @@ describe('updateWorkItem unit', () => {
       updateWorkItem(mockConnection, 123, { title: 'Updated Title' }),
     ).rejects.toThrow('Failed to update work item: Unexpected error');
   });
+
+  test('should overwrite tags directly when tags parameter is provided', async () => {
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tags: ['tag1', 'tag2'],
+    });
+
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: 'tag1; tag2',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should clear tags when tags parameter is empty array', async () => {
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tags: [],
+    });
+
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: '',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should fetch and add tags when tagsToAdd is provided', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: {
+        'System.Tags': 'existing1; existing2',
+      },
+    });
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tagsToAdd: ['existing2', 'newTag'],
+    });
+
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.Tags']);
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: 'existing1; existing2; newTag',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should fetch and remove tags when tagsToRemove is provided', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: {
+        'System.Tags': 'existing1; existing2; existing3',
+      },
+    });
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tagsToRemove: ['existing2', 'nonExistent'],
+    });
+
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.Tags']);
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: 'existing1; existing3',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
 });

--- a/src/features/work-items/update-work-item/feature.spec.unit.ts
+++ b/src/features/work-items/update-work-item/feature.spec.unit.ts
@@ -68,7 +68,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'tag1; tag2',
         },
@@ -98,7 +98,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: '',
         },
@@ -136,7 +136,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'existing1; existing2; newTag',
         },
@@ -174,7 +174,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'existing1; existing3',
         },

--- a/src/features/work-items/update-work-item/feature.spec.unit.ts
+++ b/src/features/work-items/update-work-item/feature.spec.unit.ts
@@ -68,7 +68,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'replace',
+          op: 'add',
           path: '/fields/System.Tags',
           value: 'tag1; tag2',
         },
@@ -98,7 +98,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'replace',
+          op: 'add',
           path: '/fields/System.Tags',
           value: '',
         },
@@ -136,7 +136,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'replace',
+          op: 'add',
           path: '/fields/System.Tags',
           value: 'existing1; existing2; newTag',
         },
@@ -174,9 +174,83 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'replace',
+          op: 'add',
           path: '/fields/System.Tags',
           value: 'existing1; existing3',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should remove tags case-insensitively', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: {
+        'System.Tags': 'Bug; Feature; Enhancement',
+      },
+    });
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tagsToRemove: ['bug', 'FEATURE'],
+    });
+
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: 'Enhancement',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should not add duplicate tags case-insensitively', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: {
+        'System.Tags': 'Bug; Feature',
+      },
+    });
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tagsToAdd: ['bug', 'NewTag'],
+    });
+
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'add',
+          path: '/fields/System.Tags',
+          value: 'Bug; Feature; NewTag',
         },
       ],
       123,

--- a/src/features/work-items/update-work-item/feature.spec.unit.ts
+++ b/src/features/work-items/update-work-item/feature.spec.unit.ts
@@ -52,10 +52,15 @@ describe('updateWorkItem unit', () => {
     ).rejects.toThrow('Failed to update work item: Unexpected error');
   });
 
-  test('should overwrite tags directly when tags parameter is provided', async () => {
+  test('should overwrite tags using replace when existing tags are present', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: { 'System.Tags': 'old1; old2' },
+    });
     const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
     const mockConnection: any = {
       getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
         updateWorkItem: mockUpdateWorkItem,
       }),
     };
@@ -64,6 +69,43 @@ describe('updateWorkItem unit', () => {
       tags: ['tag1', 'tag2'],
     });
 
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.Tags']);
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'replace',
+          path: '/fields/System.Tags',
+          value: 'tag1; tag2',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should overwrite tags using add when no existing tags', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: {},
+    });
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tags: ['tag1', 'tag2'],
+    });
+
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.Tags']);
     expect(mockUpdateWorkItem).toHaveBeenCalledWith(
       {},
       [
@@ -82,10 +124,15 @@ describe('updateWorkItem unit', () => {
     );
   });
 
-  test('should clear tags when tags parameter is empty array', async () => {
+  test('should clear tags using replace when existing tags are present', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: { 'System.Tags': 'old1; old2' },
+    });
     const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
     const mockConnection: any = {
       getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
         updateWorkItem: mockUpdateWorkItem,
       }),
     };
@@ -94,6 +141,43 @@ describe('updateWorkItem unit', () => {
       tags: [],
     });
 
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.Tags']);
+    expect(mockUpdateWorkItem).toHaveBeenCalledWith(
+      {},
+      [
+        {
+          op: 'replace',
+          path: '/fields/System.Tags',
+          value: '',
+        },
+      ],
+      123,
+      undefined,
+      false,
+      false,
+      false,
+      expect.any(Number),
+    );
+  });
+
+  test('should clear tags using add when no existing tags', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      id: 123,
+      fields: {},
+    });
+    const mockUpdateWorkItem = jest.fn().mockResolvedValue({ id: 123 });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        updateWorkItem: mockUpdateWorkItem,
+      }),
+    };
+
+    await updateWorkItem(mockConnection, 123, {
+      tags: [],
+    });
+
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.Tags']);
     expect(mockUpdateWorkItem).toHaveBeenCalledWith(
       {},
       [
@@ -136,7 +220,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'existing1; existing2; newTag',
         },
@@ -174,7 +258,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'existing1; existing3',
         },
@@ -211,7 +295,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'Enhancement',
         },
@@ -248,7 +332,7 @@ describe('updateWorkItem unit', () => {
       {},
       [
         {
-          op: 'add',
+          op: 'replace',
           path: '/fields/System.Tags',
           value: 'Bug; Feature; NewTag',
         },

--- a/src/features/work-items/update-work-item/feature.ts
+++ b/src/features/work-items/update-work-item/feature.ts
@@ -83,6 +83,54 @@ export async function updateWorkItem(
       });
     }
 
+    // Add tags logic
+    if (options.tags !== undefined) {
+      document.push({
+        op: 'add',
+        path: '/fields/System.Tags',
+        value: options.tags.length > 0 ? options.tags.join('; ') : '',
+      });
+    } else if (
+      (options.tagsToAdd && options.tagsToAdd.length > 0) ||
+      (options.tagsToRemove && options.tagsToRemove.length > 0)
+    ) {
+      const currentWorkItem = await witApi.getWorkItem(workItemId, [
+        'System.Tags',
+      ]);
+      if (!currentWorkItem) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Work item '${workItemId}' not found`,
+        );
+      }
+
+      const currentTagsStr =
+        (currentWorkItem.fields?.['System.Tags'] as string) || '';
+      let tagsList = currentTagsStr
+        .split(';')
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      if (options.tagsToAdd) {
+        for (const tag of options.tagsToAdd) {
+          const trimmed = tag.trim();
+          if (trimmed && !tagsList.includes(trimmed)) {
+            tagsList.push(trimmed);
+          }
+        }
+      }
+
+      if (options.tagsToRemove) {
+        const toRemove = new Set(options.tagsToRemove.map((t) => t.trim()));
+        tagsList = tagsList.filter((t) => !toRemove.has(t));
+      }
+
+      document.push({
+        op: 'add',
+        path: '/fields/System.Tags',
+        value: tagsList.length > 0 ? tagsList.join('; ') : '',
+      });
+    }
+
     // Add any additional fields
     if (options.additionalFields) {
       for (const [key, value] of Object.entries(options.additionalFields)) {

--- a/src/features/work-items/update-work-item/feature.ts
+++ b/src/features/work-items/update-work-item/feature.ts
@@ -86,7 +86,7 @@ export async function updateWorkItem(
     // Add tags logic
     if (options.tags !== undefined) {
       document.push({
-        op: 'add',
+        op: 'replace',
         path: '/fields/System.Tags',
         value: options.tags.length > 0 ? options.tags.join('; ') : '',
       });
@@ -125,7 +125,7 @@ export async function updateWorkItem(
       }
 
       document.push({
-        op: 'add',
+        op: 'replace',
         path: '/fields/System.Tags',
         value: tagsList.length > 0 ? tagsList.join('; ') : '',
       });

--- a/src/features/work-items/update-work-item/feature.ts
+++ b/src/features/work-items/update-work-item/feature.ts
@@ -86,7 +86,7 @@ export async function updateWorkItem(
     // Add tags logic
     if (options.tags !== undefined) {
       document.push({
-        op: 'replace',
+        op: 'add',
         path: '/fields/System.Tags',
         value: options.tags.length > 0 ? options.tags.join('; ') : '',
       });
@@ -113,19 +113,25 @@ export async function updateWorkItem(
       if (options.tagsToAdd) {
         for (const tag of options.tagsToAdd) {
           const trimmed = tag.trim();
-          if (trimmed && !tagsList.includes(trimmed)) {
+          const trimmedLower = trimmed.toLowerCase();
+          if (
+            trimmed &&
+            !tagsList.some((t) => t.toLowerCase() === trimmedLower)
+          ) {
             tagsList.push(trimmed);
           }
         }
       }
 
       if (options.tagsToRemove) {
-        const toRemove = new Set(options.tagsToRemove.map((t) => t.trim()));
-        tagsList = tagsList.filter((t) => !toRemove.has(t));
+        const toRemove = new Set(
+          options.tagsToRemove.map((t) => t.trim().toLowerCase()),
+        );
+        tagsList = tagsList.filter((t) => !toRemove.has(t.toLowerCase()));
       }
 
       document.push({
-        op: 'replace',
+        op: 'add',
         path: '/fields/System.Tags',
         value: tagsList.length > 0 ? tagsList.join('; ') : '',
       });

--- a/src/features/work-items/update-work-item/feature.ts
+++ b/src/features/work-items/update-work-item/feature.ts
@@ -84,9 +84,23 @@ export async function updateWorkItem(
     }
 
     // Add tags logic
+    // Azure DevOps treats op:'add' on System.Tags as additive (merge) rather
+    // than a full replacement.  Use op:'replace' to truly overwrite when the
+    // field already has a value; fall back to op:'add' when it is empty
+    // (JSON-Patch 'replace' fails on a missing/empty field).
     if (options.tags !== undefined) {
+      const currentWorkItem = await witApi.getWorkItem(workItemId, [
+        'System.Tags',
+      ]);
+      if (!currentWorkItem) {
+        throw new AzureDevOpsResourceNotFoundError(
+          `Work item '${workItemId}' not found`,
+        );
+      }
+      const currentTagsStr =
+        (currentWorkItem.fields?.['System.Tags'] as string) || '';
       document.push({
-        op: 'add',
+        op: currentTagsStr ? 'replace' : 'add',
         path: '/fields/System.Tags',
         value: options.tags.length > 0 ? options.tags.join('; ') : '',
       });
@@ -131,7 +145,7 @@ export async function updateWorkItem(
       }
 
       document.push({
-        op: 'add',
+        op: currentTagsStr ? 'replace' : 'add',
         path: '/fields/System.Tags',
         value: tagsList.length > 0 ? tagsList.join('; ') : '',
       });


### PR DESCRIPTION
This PR implements Issue #297: "Missing feature - ability to remove tags from a work item".

### Changes:
- **Schemas & Types**:
  - Added optional parameter `tags` (string array) to `CreateWorkItemSchema` and `CreateWorkItemOptions`.
  - Added optional parameters `tags` (string array), `tagsToAdd` (string array), and `tagsToRemove` (string array) to `UpdateWorkItemSchema` and `UpdateWorkItemOptions`.
- **Request Handling (`src/features/work-items/index.ts`)**:
  - Mapped the new tag arguments to `createWorkItem` and `updateWorkItem` features.
- **Create Feature (`src/features/work-items/create-work-item/feature.ts`)**:
  - Included a JSON patch `'add'` operation for `System.Tags` if `options.tags` is non-empty.
- **Update Feature (`src/features/work-items/update-work-item/feature.ts`)**:
  - Overwrites existing tags if `options.tags` is defined, clearing them with `''` if empty.
  - Fetches existing tags from the work item and applies add/remove logic if `tagsToAdd` or `tagsToRemove` are specified.
- **Tests**:
  - Added unit tests covering tag operations (overwrite, append, remove, clear) in `src/features/work-items/update-work-item/feature.spec.unit.ts`.
  - Added integration tests covering tag scenarios in `src/features/work-items/update-work-item/feature.spec.int.ts`.
