### PR TITLE
feat: add get_work_item_comments tool (#276)

### DIFF
--- a/src/features/work-items/get-work-item-comments/feature.spec.int.ts
+++ b/src/features/work-items/get-work-item-comments/feature.spec.int.ts
@@ -1,0 +1,111 @@
+import { WebApi } from 'azure-devops-node-api';
+import { getWorkItemComments } from './feature';
+import {
+  getTestConnection,
+  shouldSkipIntegrationTest,
+} from '../__test__/test-helpers';
+import { AzureDevOpsResourceNotFoundError } from '../../../shared/errors';
+import { createWorkItem } from '../create-work-item/feature';
+import { CreateWorkItemOptions } from '../types';
+
+const shouldSkip = shouldSkipIntegrationTest();
+const describeOrSkip = shouldSkip ? describe.skip : describe;
+
+describeOrSkip('getWorkItemComments integration', () => {
+  let connection: WebApi;
+  let testWorkItemId: number;
+  let projectName: string;
+
+  beforeAll(async () => {
+    // Get a real connection using environment variables
+    const testConnection = await getTestConnection();
+    if (!testConnection) {
+      throw new Error(
+        'Connection should be available when integration tests are enabled',
+      );
+    }
+    connection = testConnection;
+    projectName = process.env.AZURE_DEVOPS_DEFAULT_PROJECT || 'DefaultProject';
+
+    // Create a test work item
+    const uniqueTitle = `Test Work Item Comments ${new Date().toISOString()}`;
+    const options: CreateWorkItemOptions = {
+      title: uniqueTitle,
+      description:
+        'Test work item for get-work-item-comments integration tests',
+    };
+
+    const testWorkItem = await createWorkItem(
+      connection,
+      projectName,
+      'Task',
+      options,
+    );
+
+    if (!testWorkItem?.id) {
+      throw new Error(
+        'Failed to create required work item for testing comments',
+      );
+    }
+
+    testWorkItemId = testWorkItem.id;
+
+    // Add comments to the work item
+    const witApi = await connection.getWorkItemTrackingApi();
+    await witApi.addComment(
+      { text: 'First test comment' },
+      projectName,
+      testWorkItemId,
+    );
+    await witApi.addComment(
+      { text: 'Second test comment' },
+      projectName,
+      testWorkItemId,
+    );
+  });
+
+  test('should retrieve comments with projectId provided', async () => {
+    const result = await getWorkItemComments(connection, {
+      workItemId: testWorkItemId,
+      projectId: projectName,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.comments).toBeDefined();
+    expect(result.comments?.length).toBeGreaterThanOrEqual(2);
+
+    // Check if comments content is retrieved
+    const texts = result.comments?.map((c) => c.text);
+    expect(texts).toContain('First test comment');
+    expect(texts).toContain('Second test comment');
+  });
+
+  test('should retrieve comments and resolve projectId automatically if not provided', async () => {
+    const result = await getWorkItemComments(connection, {
+      workItemId: testWorkItemId,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.comments).toBeDefined();
+    expect(result.comments?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('should support pagination options (top)', async () => {
+    const result = await getWorkItemComments(connection, {
+      workItemId: testWorkItemId,
+      projectId: projectName,
+      top: 1,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.comments).toBeDefined();
+    expect(result.comments?.length).toBe(1);
+  });
+
+  test('should throw AzureDevOpsResourceNotFoundError for non-existent work item', async () => {
+    const nonExistentId = 999999999;
+    await expect(
+      getWorkItemComments(connection, { workItemId: nonExistentId }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
+  });
+});

--- a/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
+++ b/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
@@ -1,0 +1,94 @@
+import { getWorkItemComments } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+import {
+  CommentExpandOptions,
+  CommentSortOrder,
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+
+describe('getWorkItemComments unit', () => {
+  test('should propagate custom errors when thrown internally', async () => {
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new AzureDevOpsError('Custom error');
+      }),
+    };
+
+    await expect(
+      getWorkItemComments(mockConnection, { workItemId: 123 }),
+    ).rejects.toThrow(AzureDevOpsError);
+    await expect(
+      getWorkItemComments(mockConnection, { workItemId: 123 }),
+    ).rejects.toThrow('Custom error');
+  });
+
+  test('should wrap unexpected errors in a friendly error message', async () => {
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockImplementation(() => {
+        throw new Error('Unexpected error');
+      }),
+    };
+
+    await expect(
+      getWorkItemComments(mockConnection, { workItemId: 123 }),
+    ).rejects.toThrow('Failed to get work item comments: Unexpected error');
+  });
+
+  test('should call getComments with correct parameters when projectId is provided', async () => {
+    const mockGetComments = jest.fn().mockResolvedValue({ comments: [] });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getComments: mockGetComments,
+      }),
+    };
+
+    await getWorkItemComments(mockConnection, {
+      workItemId: 123,
+      projectId: 'myProject',
+      top: 5,
+      continuationToken: 'token123',
+      includeDeleted: true,
+      expand: 'reactions',
+      order: 'desc',
+    });
+
+    expect(mockGetComments).toHaveBeenCalledWith(
+      'myProject',
+      123,
+      5,
+      'token123',
+      true,
+      CommentExpandOptions.Reactions,
+      CommentSortOrder.Desc,
+    );
+  });
+
+  test('should fetch work item to resolve project when projectId is not provided', async () => {
+    const mockGetWorkItem = jest.fn().mockResolvedValue({
+      fields: {
+        'System.TeamProject': 'resolvedProject',
+      },
+    });
+    const mockGetComments = jest.fn().mockResolvedValue({ comments: [] });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: mockGetWorkItem,
+        getComments: mockGetComments,
+      }),
+    };
+
+    await getWorkItemComments(mockConnection, {
+      workItemId: 123,
+    });
+
+    expect(mockGetWorkItem).toHaveBeenCalledWith(123, ['System.TeamProject']);
+    expect(mockGetComments).toHaveBeenCalledWith(
+      'resolvedProject',
+      123,
+      undefined,
+      undefined,
+      undefined,
+      CommentExpandOptions.All,
+      CommentSortOrder.Asc,
+    );
+  });
+});

--- a/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
+++ b/src/features/work-items/get-work-item-comments/feature.spec.unit.ts
@@ -1,5 +1,8 @@
 import { getWorkItemComments } from './feature';
-import { AzureDevOpsError } from '../../../shared/errors';
+import {
+  AzureDevOpsError,
+  AzureDevOpsResourceNotFoundError,
+} from '../../../shared/errors';
 import {
   CommentExpandOptions,
   CommentSortOrder,
@@ -90,5 +93,37 @@ describe('getWorkItemComments unit', () => {
       CommentExpandOptions.All,
       CommentSortOrder.Asc,
     );
+  });
+
+  test('should map 404 project resolution errors to resource not found', async () => {
+    const notFoundError = Object.assign(new Error('Not found'), {
+      statusCode: 404,
+    });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: jest.fn().mockRejectedValue(notFoundError),
+        getComments: jest.fn(),
+      }),
+    };
+
+    await expect(
+      getWorkItemComments(mockConnection, { workItemId: 123 }),
+    ).rejects.toThrow(AzureDevOpsResourceNotFoundError);
+  });
+
+  test('should preserve non-404 project resolution errors', async () => {
+    const forbiddenError = Object.assign(new Error('Forbidden'), {
+      statusCode: 403,
+    });
+    const mockConnection: any = {
+      getWorkItemTrackingApi: jest.fn().mockResolvedValue({
+        getWorkItem: jest.fn().mockRejectedValue(forbiddenError),
+        getComments: jest.fn(),
+      }),
+    };
+
+    await expect(
+      getWorkItemComments(mockConnection, { workItemId: 123 }),
+    ).rejects.toThrow('Failed to get work item comments: Forbidden');
   });
 });

--- a/src/features/work-items/get-work-item-comments/feature.ts
+++ b/src/features/work-items/get-work-item-comments/feature.ts
@@ -1,0 +1,108 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  CommentExpandOptions,
+  CommentSortOrder,
+} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
+import {
+  AzureDevOpsResourceNotFoundError,
+  AzureDevOpsError,
+} from '../../../shared/errors';
+import { GetWorkItemCommentsOptions, CommentList } from '../types';
+
+/**
+ * Maps string-based expansion options to the CommentExpandOptions enum
+ */
+const expandMap: Record<string, CommentExpandOptions> = {
+  none: CommentExpandOptions.None,
+  reactions: CommentExpandOptions.Reactions,
+  renderedtext: CommentExpandOptions.RenderedText,
+  all: CommentExpandOptions.All,
+};
+
+/**
+ * Maps string-based sort order options to the CommentSortOrder enum
+ */
+const orderMap: Record<string, CommentSortOrder> = {
+  asc: CommentSortOrder.Asc,
+  desc: CommentSortOrder.Desc,
+};
+
+/**
+ * Get comments for a work item
+ *
+ * @param connection The Azure DevOps WebApi connection
+ * @param options Options for getting work item comments
+ * @returns The list of work item comments
+ */
+export async function getWorkItemComments(
+  connection: WebApi,
+  options: GetWorkItemCommentsOptions,
+): Promise<CommentList> {
+  try {
+    const witApi = await connection.getWorkItemTrackingApi();
+    const {
+      workItemId,
+      projectId,
+      top,
+      continuationToken,
+      includeDeleted,
+      expand = 'all',
+      order = 'asc',
+    } = options;
+
+    let resolvedProjectId = projectId;
+    if (!resolvedProjectId) {
+      try {
+        const workItem = await witApi.getWorkItem(workItemId, [
+          'System.TeamProject',
+        ]);
+        if (
+          !workItem ||
+          !workItem.fields ||
+          !workItem.fields['System.TeamProject']
+        ) {
+          throw new AzureDevOpsResourceNotFoundError(
+            `Work item '${workItemId}' not found`,
+          );
+        }
+        resolvedProjectId = workItem.fields['System.TeamProject'];
+      } catch (error) {
+        if (error instanceof AzureDevOpsError) {
+          throw error;
+        }
+        throw new AzureDevOpsResourceNotFoundError(
+          `Work item '${workItemId}' not found`,
+        );
+      }
+    }
+
+    const expandVal =
+      expandMap[expand.toLowerCase()] ?? CommentExpandOptions.All;
+    const orderVal = orderMap[order.toLowerCase()] ?? CommentSortOrder.Asc;
+
+    const commentList = await witApi.getComments(
+      resolvedProjectId!,
+      workItemId,
+      top,
+      continuationToken,
+      includeDeleted,
+      expandVal,
+      orderVal,
+    );
+
+    if (!commentList) {
+      throw new AzureDevOpsResourceNotFoundError(
+        `Comments for work item '${workItemId}' not found`,
+      );
+    }
+
+    return commentList;
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new AzureDevOpsError(
+      `Failed to get work item comments: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/work-items/get-work-item-comments/feature.ts
+++ b/src/features/work-items/get-work-item-comments/feature.ts
@@ -27,6 +27,19 @@ const orderMap: Record<string, CommentSortOrder> = {
   desc: CommentSortOrder.Desc,
 };
 
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const errorObj = error as {
+    statusCode?: number;
+    response?: { status?: number };
+  };
+
+  return errorObj.statusCode === 404 || errorObj.response?.status === 404;
+}
+
 /**
  * Get comments for a work item
  *
@@ -70,9 +83,12 @@ export async function getWorkItemComments(
         if (error instanceof AzureDevOpsError) {
           throw error;
         }
-        throw new AzureDevOpsResourceNotFoundError(
-          `Work item '${workItemId}' not found`,
-        );
+        if (isNotFoundError(error)) {
+          throw new AzureDevOpsResourceNotFoundError(
+            `Work item '${workItemId}' not found`,
+          );
+        }
+        throw error;
       }
     }
 

--- a/src/features/work-items/get-work-item-comments/index.ts
+++ b/src/features/work-items/get-work-item-comments/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './feature';

--- a/src/features/work-items/get-work-item-comments/schema.ts
+++ b/src/features/work-items/get-work-item-comments/schema.ts
@@ -1,0 +1,3 @@
+import { GetWorkItemCommentsSchema } from '../schemas';
+
+export { GetWorkItemCommentsSchema };

--- a/src/features/work-items/index.spec.unit.ts
+++ b/src/features/work-items/index.spec.unit.ts
@@ -24,6 +24,10 @@ jest.mock('./manage-work-item-link', () => ({
   manageWorkItemLink: jest.fn(),
 }));
 
+jest.mock('./get-work-item-comments', () => ({
+  getWorkItemComments: jest.fn(),
+}));
+
 // Helper function to create a valid CallToolRequest object
 const createCallToolRequest = (name: string, args: any): CallToolRequest => {
   return {
@@ -44,6 +48,7 @@ describe('Work Items Request Handlers', () => {
         'create_work_item',
         'update_work_item',
         'manage_work_item_link',
+        'get_work_item_comments',
       ];
 
       workItemsRequests.forEach((name) => {
@@ -109,6 +114,20 @@ describe('Work Items Request Handlers', () => {
           };
         });
 
+      jest
+        .spyOn(workItemModule.GetWorkItemCommentsSchema, 'parse')
+        .mockImplementation(() => {
+          return {
+            workItemId: 123,
+            projectId: 'myProject',
+            top: 5,
+            continuationToken: 'token123',
+            includeDeleted: true,
+            expand: 'all',
+            order: 'asc',
+          };
+        });
+
       // Setup mocks for feature functions
       jest.spyOn(workItemModule, 'getWorkItem').mockResolvedValue({ id: 123 });
       jest
@@ -123,6 +142,9 @@ describe('Work Items Request Handlers', () => {
       jest
         .spyOn(workItemModule, 'manageWorkItemLink')
         .mockResolvedValue({ id: 123 });
+      jest.spyOn(workItemModule, 'getWorkItemComments').mockResolvedValue({
+        comments: [{ id: 1 }],
+      });
     });
 
     afterEach(() => {
@@ -238,6 +260,52 @@ describe('Work Items Request Handlers', () => {
       await expect(
         handleWorkItemsRequest(mockConnection, request),
       ).rejects.toThrow('Unknown work items tool: unknown_tool');
+    });
+
+    it('should handle get_work_item_comments requests', async () => {
+      const request = createCallToolRequest('get_work_item_comments', {
+        workItemId: 123,
+        projectId: 'myProject',
+        top: 5,
+        continuationToken: 'token123',
+        includeDeleted: true,
+        expand: 'all',
+        order: 'asc',
+      });
+
+      const result = await handleWorkItemsRequest(mockConnection, request);
+
+      expect(
+        workItemModule.GetWorkItemCommentsSchema.parse,
+      ).toHaveBeenCalledWith({
+        workItemId: 123,
+        projectId: 'myProject',
+        top: 5,
+        continuationToken: 'token123',
+        includeDeleted: true,
+        expand: 'all',
+        order: 'asc',
+      });
+      expect(workItemModule.getWorkItemComments).toHaveBeenCalledWith(
+        mockConnection,
+        {
+          workItemId: 123,
+          projectId: 'myProject',
+          top: 5,
+          continuationToken: 'token123',
+          includeDeleted: true,
+          expand: 'all',
+          order: 'asc',
+        },
+      );
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ comments: [{ id: 1 }] }, null, 2),
+          },
+        ],
+      });
     });
   });
 });

--- a/src/features/work-items/index.ts
+++ b/src/features/work-items/index.ts
@@ -8,6 +8,7 @@ export * from './get-work-item';
 export * from './create-work-item';
 export * from './update-work-item';
 export * from './manage-work-item-link';
+export * from './get-work-item-comments';
 
 // Export tool definitions
 export * from './tool-definitions';
@@ -26,11 +27,13 @@ import {
   CreateWorkItemSchema,
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
+  GetWorkItemCommentsSchema,
   listWorkItems,
   getWorkItem,
   createWorkItem,
   updateWorkItem,
   manageWorkItemLink,
+  getWorkItemComments,
 } from './';
 
 // Define the response type based on observed usage
@@ -51,6 +54,7 @@ export const isWorkItemsRequest: RequestIdentifier = (
     'create_work_item',
     'update_work_item',
     'manage_work_item_link',
+    'get_work_item_comments',
   ].includes(toolName);
 };
 
@@ -142,6 +146,21 @@ export const handleWorkItemsRequest: RequestHandler = async (
           comment: args.comment,
         },
       );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_work_item_comments': {
+      const args = GetWorkItemCommentsSchema.parse(request.params.arguments);
+      const result = await getWorkItemComments(connection, {
+        workItemId: args.workItemId,
+        projectId: args.projectId,
+        top: args.top,
+        continuationToken: args.continuationToken,
+        includeDeleted: args.includeDeleted,
+        expand: args.expand,
+        order: args.order,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -175,14 +175,14 @@ export const GetWorkItemCommentsSchema = z.object({
   includeDeleted: z.boolean().optional().describe('Include deleted comments'),
   expand: z
     .enum(['none', 'reactions', 'renderedText', 'all'])
-    .default('all')
     .optional()
+    .default('all')
     .describe(
       'The level of detail to include in the comments response (Default: "all")',
     ),
   order: z
     .enum(['asc', 'desc'])
-    .default('asc')
     .optional()
+    .default('asc')
     .describe('The order in which to sort the comments (Default: "asc")'),
 });

--- a/src/features/work-items/schemas.ts
+++ b/src/features/work-items/schemas.ts
@@ -160,3 +160,29 @@ export const ManageWorkItemLinkSchema = z.object({
     .optional()
     .describe('Optional comment explaining the link'),
 });
+
+/**
+ * Schema for getting work item comments
+ */
+export const GetWorkItemCommentsSchema = z.object({
+  workItemId: z.number().describe('The ID of the work item'),
+  projectId: z.string().optional().describe('The ID or name of the project'),
+  top: z.number().optional().describe('Maximum number of comments to return'),
+  continuationToken: z
+    .string()
+    .optional()
+    .describe('Continuation token to retrieve the next page of comments'),
+  includeDeleted: z.boolean().optional().describe('Include deleted comments'),
+  expand: z
+    .enum(['none', 'reactions', 'renderedText', 'all'])
+    .default('all')
+    .optional()
+    .describe(
+      'The level of detail to include in the comments response (Default: "all")',
+    ),
+  order: z
+    .enum(['asc', 'desc'])
+    .default('asc')
+    .optional()
+    .describe('The order in which to sort the comments (Default: "asc")'),
+});

--- a/src/features/work-items/tool-definitions.ts
+++ b/src/features/work-items/tool-definitions.ts
@@ -6,6 +6,7 @@ import {
   UpdateWorkItemSchema,
   ManageWorkItemLinkSchema,
   GetWorkItemSchema,
+  GetWorkItemCommentsSchema,
 } from './schemas';
 
 /**
@@ -36,5 +37,10 @@ export const workItemsTools: ToolDefinition[] = [
     name: 'manage_work_item_link',
     description: 'Add or remove links between work items',
     inputSchema: zodToJsonSchema(ManageWorkItemLinkSchema),
+  },
+  {
+    name: 'get_work_item_comments',
+    description: 'Get comments and discussion history for a specific work item',
+    inputSchema: zodToJsonSchema(GetWorkItemCommentsSchema),
   },
 ];

--- a/src/features/work-items/types.ts
+++ b/src/features/work-items/types.ts
@@ -1,6 +1,7 @@
 import {
   WorkItem,
   WorkItemReference,
+  CommentList,
 } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
 
 /**
@@ -47,5 +48,18 @@ export interface UpdateWorkItemOptions {
   additionalFields?: Record<string, string | number | boolean | null>;
 }
 
-// Re-export WorkItem and WorkItemReference types for convenience
-export type { WorkItem, WorkItemReference };
+/**
+ * Options for getting work item comments
+ */
+export interface GetWorkItemCommentsOptions {
+  workItemId: number;
+  projectId?: string;
+  top?: number;
+  continuationToken?: string;
+  includeDeleted?: boolean;
+  expand?: 'none' | 'reactions' | 'renderedText' | 'all';
+  order?: 'asc' | 'desc';
+}
+
+// Re-export WorkItem, WorkItemReference and CommentList types for convenience
+export type { WorkItem, WorkItemReference, CommentList };


### PR DESCRIPTION
This PR implements Issue #276 by adding the `get_work_item_comments` tool to fetch comments and discussion history for a work item.

### Summary of Changes:
- Created and exported `GetWorkItemCommentsSchema` in `src/features/work-items/schemas.ts`
- Exported `GetWorkItemCommentsOptions` and re-exported `CommentList` type in `src/features/work-items/types.ts`
- Created directory `src/features/work-items/get-work-item-comments/` with:
  - `schema.ts`: Re-export the schema
  - `feature.ts`: Implement `getWorkItemComments` using `witApi.getComments` and mapping expand/sort parameters to SDK enums. Also includes smart project resolution using `witApi.getWorkItem` when `projectId` is omitted.
  - `index.ts`: Export schema and feature
- Registered `get_work_item_comments` as a tool in `src/features/work-items/index.ts` and `src/features/work-items/tool-definitions.ts`
- Wrote unit tests in `src/features/work-items/get-work-item-comments/feature.spec.unit.ts` and integration tests in `src/features/work-items/get-work-item-comments/feature.spec.int.ts`
- Verified that all unit and integration tests compile, format, and pass.
