### PR TITLE
fix(docs): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](https://github.com/tiber
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tiberriver256/mcp-server-azure-devops&type=Date)](https://www.star-history.com/#tiberriver256/mcp-server-azure-devops&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tiberriver256/mcp-server-azure-devops&type=Date)](https://star-history.dera.page/#tiberriver256/mcp-server-azure-devops&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change restores it by pointing to star-history.dera.page, which uses an alternative data source that requires no API token.