### PR TITLE
chore(deps): upgrade azure-devops-node-api 13 to 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@azure/identity": "^4.13.2",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.20.0",
-        "azure-devops-node-api": "^13.0.0",
+        "azure-devops-node-api": "^17.0.0",
         "diff": "^8.0.4",
         "dotenv": "^16.3.1",
         "jszip": "^3.10.1",
@@ -2631,13 +2631,16 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-13.0.0.tgz",
-      "integrity": "sha512-T/i3pt2Dxb2//1+TJT05Ff5heUmQEWKwa8sdguIhdRYT3Zge9FYw98zpfFvCD7CZsz6AN74SKGgqF3ISVN2TGg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha512-Ej/C91R56m98p99B6RoePnCsWH2NEME1a7rYE7WWyX8AMuIILEDFyVlwRypfHOSJTTRJZVHkXISkPDqs6To/HQ==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.4"
+        "typed-rest-client": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3877,6 +3880,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/detect-file": {
@@ -6478,6 +6491,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7607,6 +7626,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
@@ -9420,14 +9445,35 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha512-8fMeur8aKaJw8WsqYUZD4CsUfpMFH3zWlRQigM3KWs406KGjqPMdTBn7RfIpMvPjZ1bH+S8QwG+FK/VY/8ndKg==",
       "license": "MIT",
       "dependencies": {
-        "qs": "^6.9.1",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/typed-rest-client/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "^1.20.0",
         "azure-devops-node-api": "^17.0.0",
         "diff": "^8.0.4",
-        "dotenv": "^16.3.1",
+        "dotenv": "^17.4.2",
         "jszip": "^3.10.1",
         "minimatch": "^10.2.6",
         "zod": "^3.24.2",
@@ -3968,9 +3968,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@azure/identity": "^4.13.2",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.20.0",
-    "azure-devops-node-api": "^13.0.0",
+    "azure-devops-node-api": "^17.0.0",
     "diff": "^8.0.4",
     "dotenv": "^16.3.1",
     "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "axios": "^1.20.0",
     "azure-devops-node-api": "^17.0.0",
     "diff": "^8.0.4",
-    "dotenv": "^16.3.1",
+    "dotenv": "^17.4.2",
     "jszip": "^3.10.1",
     "minimatch": "^10.2.6",
     "zod": "^3.24.2",


### PR DESCRIPTION
Upgrades azure-devops-node-api 13.0.0 to 17.0.0.

Validation so far:
- npm run build: clean
- npm run lint: clean
- npm run test:unit: 62 suites, 392 tests pass
- npm run test:int: 35 suites skip locally (no credentials); CI runs them against eShopOnWeb
- npm audit --audit-level=high: clean (3 moderate remain, from qs via typed-rest-client inside node-api 17 itself; fix requires downgrade, so accepted)

Follow-ups on this branch if green: dotenv 16 to 17. Zod v4 stays out (SDK still accepts v3).