### PR TITLE
fix: align createWikiPage unit tests with api-version change

### DIFF
--- a/src/features/wikis/create-wiki-page/feature.spec.unit.ts
+++ b/src/features/wikis/create-wiki-page/feature.spec.unit.ts
@@ -59,7 +59,7 @@ describe('createWikiPage Feature', () => {
 
     expect(mockPut).toHaveBeenCalledTimes(1);
     expect(mockPut).toHaveBeenCalledWith(
-      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1-preview.1',
+      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1',
       { content: 'Hello world' },
     );
   });
@@ -73,7 +73,7 @@ describe('createWikiPage Feature', () => {
     await createWikiPage(paramsWithProject, client as any);
 
     expect(mockPut).toHaveBeenCalledWith(
-      'defaultOrg/customProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1-preview.1',
+      'defaultOrg/customProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1',
       { content: 'Hello world' },
     );
   });
@@ -87,7 +87,7 @@ describe('createWikiPage Feature', () => {
     await createWikiPage(paramsWithOrg, client as any);
 
     expect(mockPut).toHaveBeenCalledWith(
-      'customOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1-preview.1',
+      'customOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1',
       { content: 'Hello world' },
     );
   });
@@ -111,7 +111,7 @@ describe('createWikiPage Feature', () => {
     await createWikiPage(paramsWithNullProject, clientWithoutProject as any);
 
     expect(mockPut).toHaveBeenCalledWith(
-      'defaultOrg/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1-preview.1',
+      'defaultOrg/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1',
       { content: 'Hello world' },
     );
   });
@@ -125,7 +125,7 @@ describe('createWikiPage Feature', () => {
     await createWikiPage(paramsWithPath, client as any);
 
     expect(mockPut).toHaveBeenCalledWith(
-      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2FMy%20Test%20Page%2FSub%20Page&api-version=7.1-preview.1',
+      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2FMy%20Test%20Page%2FSub%20Page&api-version=7.1',
       { content: 'Hello world' },
     );
   });
@@ -139,7 +139,7 @@ describe('createWikiPage Feature', () => {
     await createWikiPage(paramsWithPath, client as any);
 
     expect(mockPut).toHaveBeenCalledWith(
-      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1-preview.1',
+      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1',
       { content: 'Hello world' },
     );
   });
@@ -153,7 +153,7 @@ describe('createWikiPage Feature', () => {
     await createWikiPage(paramsWithComment, client as any);
 
     expect(mockPut).toHaveBeenCalledWith(
-      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1-preview.1',
+      'defaultOrg/defaultProject/_apis/wiki/wikis/test-wiki/pages?path=%2F&api-version=7.1',
       { content: 'Hello world', comment: 'Initial page creation' },
     );
   });


### PR DESCRIPTION
## Summary
- **Root cause of Dependabot CI redness:** `main` unit tests are broken after `cc6b161` changed `createWikiPage` to use `api-version=${apiVersion}` (default `7.1`) but left specs asserting `7.1-preview.1`.
- CI workflow only runs on `pull_request_target`, so main went red unnoticed; Dependabot PRs that include current main fail at **Unit Tests**. The `build` job then fails in ~2s as a gate (`CI failed (test result: failure)`).
- PR #318 was green because it ran *before* those commits and was not rebased onto them.

## Fix
Update `src/features/wikis/create-wiki-page/feature.spec.unit.ts` expectations to `api-version=7.1` to match production URL construction.

## Verification
- `npm run test:unit` → **394 passed** locally after this change (was 7 failed / 387 passed on main).

## After merge
Rebase / `@dependabot recreate` open Dependabot PRs so they pick up this fix.
- **Exception:** #324 (TypeScript 5→7) separately fails at `npm ci` — that major still needs deliberate handling, not just this test fix.

## Test plan
- [ ] CI `test` + `build` green on this PR
- [ ] After merge, confirm a non-major Dependabot PR (e.g. #323 or #319) goes green after recreate/rebase