### PR TITLE
docs: document the real api-version ceiling per on-prem release

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Key environment variables include:
 | `AZURE_DEVOPS_ORG_URL`         | Full URL to your Azure DevOps organization or Server collection (e.g., `https://server:8080/tfs/DefaultCollection`) | Yes                          | -                |
 | `AZURE_DEVOPS_PAT`             | Personal Access Token (for PAT auth)                                               | Only with PAT auth           | -                |
 | `AZURE_DEVOPS_DEFAULT_PROJECT` | Default project if none specified                                                  | No                           | -                |
-| `AZURE_DEVOPS_API_VERSION`     | REST api-version for direct REST calls (set to `7.0` for Azure DevOps Server 2022 and older) | No                           | `7.1`            |
+| `AZURE_DEVOPS_API_VERSION`     | REST api-version for the tools that call the REST API directly ([per-release values](https://github.com/tiberriver256/mcp-server-azure-devops/blob/main/docs/authentication.md#rest-api-version)) | No                           | `7.1`            |
 | `AZURE_TENANT_ID`              | Azure AD tenant ID (for service principals)                                        | Only with service principals | -                |
 | `AZURE_CLIENT_ID`              | Azure AD application ID (for service principals)                                   | Only with service principals | -                |
 | `AZURE_CLIENT_SECRET`          | Azure AD client secret (for service principals)                                    | Only with service principals | -                |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -145,11 +145,37 @@ Azure CLI authentication uses the `AzureCliCredential` class from the `@azure/id
 | `AZURE_DEVOPS_ORG_URL`         | Full URL to your Azure DevOps organization                                         | Yes                          | -                |
 | `AZURE_DEVOPS_PAT`             | Personal Access Token (for PAT auth)                                               | Only with PAT auth           | -                |
 | `AZURE_DEVOPS_DEFAULT_PROJECT` | Default project if none specified                                                  | No                           | -                |
-| `AZURE_DEVOPS_API_VERSION`     | REST api-version for direct REST calls (set to `7.0` for Azure DevOps Server 2022 and older) | No                           | `7.1`            |
+| `AZURE_DEVOPS_API_VERSION`     | REST api-version for the tools that call the REST API directly (see [REST API version](#rest-api-version)) | No                           | `7.1`            |
 | `AZURE_TENANT_ID`              | Azure AD tenant ID (for service principals)                                        | Only with service principals | -                |
 | `AZURE_CLIENT_ID`              | Azure AD application ID (for service principals)                                   | Only with service principals | -                |
 | `AZURE_CLIENT_SECRET`          | Azure AD client secret (for service principals)                                    | Only with service principals | -                |
 | `LOG_LEVEL`                    | Logging level (debug, info, warn, error)                                           | No                           | info             |
+
+### REST API version
+
+Most tools go through `azure-devops-node-api`, which negotiates the REST
+api-version with the server on its own. The pipeline, search and wiki tools call
+the REST API directly and use `AZURE_DEVOPS_API_VERSION` instead.
+
+The default `7.1` is what Azure DevOps Services expects. On-premises releases cap
+out earlier, and a version above the cap is rejected with
+`The requested REST API version of <x> is out of range for this server`:
+
+| Product                     | Highest api-version |
+| --------------------------- | ------------------- |
+| Azure DevOps Services       | `7.1`               |
+| Azure DevOps Server 2022    | `7.0`               |
+| Azure DevOps Server 2020    | `6.0`               |
+| Azure DevOps Server 2019    | `5.0`               |
+| Team Foundation Server 2018 | `4.0`               |
+
+See [REST API versioning](https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-versioning)
+for the full matrix.
+
+Known limitation: this is one value for every direct call. On `6.0` and older,
+some areas (pipelines, search) only ship as `-preview.N` revisions while others
+are stable at the same major version, so a single setting cannot satisfy both and
+part of the tools may still be rejected on those releases.
 
 ## Troubleshooting Authentication Issues
 

--- a/src/utils/environment.spec.unit.ts
+++ b/src/utils/environment.spec.unit.ts
@@ -84,7 +84,10 @@ describe('environment utilities', () => {
     };
 
     it('should default to 7.1', () => {
-      delete process.env.AZURE_DEVOPS_API_VERSION;
+      // Assign an empty value instead of deleting the key: environment.ts runs
+      // dotenv.config(), which would repopulate a deleted key from a local .env
+      // but leaves an existing one alone.
+      process.env.AZURE_DEVOPS_API_VERSION = '';
       expect(loadApiVersion()).toBe('7.1');
     });
 


### PR DESCRIPTION
Follow-up to #326, addressing the review findings that were not covered by #328.

## Docs were wrong about which servers accept `7.0`

#326 told users to set `7.0` for "Azure DevOps Server 2022 and older". Per the [REST API versioning matrix](https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-versioning), that only holds for 2022:

| Product | Highest api-version |
| --- | --- |
| Azure DevOps Services | `7.1` |
| Azure DevOps Server 2022 | `7.0` |
| Azure DevOps Server 2020 | `6.0` |
| Azure DevOps Server 2019 | `5.0` |
| Team Foundation Server 2018 | `4.0` |

A user on Server 2020 following the old wording would configure a version their server rejects. The table now lives in `docs/authentication.md` under a `REST API version` heading, and the README row links to it.

The same section states the known limitation of a single flat setting: on `6.0` and older, some areas (pipelines, search) only ship as `-preview.N` revisions while others are stable at the same major version, so one value cannot satisfy both. Resolving the version per API area would fix that properly; this PR only stops the docs from over-promising.

## Default-value test depended on the developer's `.env`

`src/utils/environment.ts` calls `dotenv.config()`. dotenv leaves an existing key alone but fills a missing one, so `delete process.env.AZURE_DEVOPS_API_VERSION` did not isolate the default — it handed control to whatever the local `.env` says. Assigning `''` still exercises the `|| '7.1'` fallback and cannot be repopulated.

Reproduced with `AZURE_DEVOPS_API_VERSION=6.0` in a local `.env`:

```
× should default to 7.1     (before)
√ should default to 7.1     (after)
```

## Tests

`npm run lint` clean. `npm run test:unit`: 391 passing. The 3 failures in `src/setup-env.spec.unit.ts` are pre-existing on Windows (the spec shells out to `setup_env.sh`; `spawnSync` returns `status: null`) and fail identically on an unmodified checkout.